### PR TITLE
Update media queries

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/packages/foundations/media-queries.ts
+++ b/packages/foundations/media-queries.ts
@@ -18,17 +18,8 @@ const maxWidth = (until: number): string =>
 const minWidthMaxWidth = (from: number, until: number): string =>
 	`@media (min-width: ${`${from}px`}) and (max-width: ${`${until - 1}px`})`
 
-// min-widths
-export const mobileMedium = minWidth(breakpointMap.mobileMedium) // MobileMedium breakpoint is 360
-export const mobileLandscape = minWidth(breakpointMap.mobileLandscape) // MobileLandscape breakpoint is 480
-export const phablet = minWidth(breakpointMap.phablet) // Phablet breakpoint is 660
-export const tablet = minWidth(breakpointMap.tablet) // Tablet breakpoint is 740
-export const desktop = minWidth(breakpointMap.desktop) // Desktop breakpoint is 980
-export const leftCol = minWidth(breakpointMap.leftCol) // leftCol breakpoint is 1140
-export const wide = minWidth(breakpointMap.wide) // Wide breakpoint is 1300
-
 // e.g. until.*
-export const until = {
+const until = {
 	mobileMedium: maxWidth(breakpointMap.mobileMedium),
 	mobileLandscape: maxWidth(breakpointMap.mobileLandscape),
 	phablet: maxWidth(breakpointMap.phablet),
@@ -39,7 +30,7 @@ export const until = {
 }
 
 // e.g. from.*.until.*
-export const from = {
+const from = {
 	mobileMedium: {
 		until: {
 			mobileLandscape: minWidthMaxWidth(
@@ -137,3 +128,13 @@ export const from = {
 		}
 	}
 }
+
+// e.g. from.*
+from.mobileMedium.toString = () => minWidth(breakpointMap.mobileMedium)
+from.mobileLandscape.toString = () => minWidth(breakpointMap.mobileLandscape)
+from.phablet.toString = () => minWidth(breakpointMap.phablet)
+from.tablet.toString = () => minWidth(breakpointMap.tablet)
+from.desktop.toString = () => minWidth(breakpointMap.desktop)
+from.leftCol.toString = () => minWidth(breakpointMap.leftCol)
+
+export { from, until }

--- a/packages/foundations/media-queries.ts
+++ b/packages/foundations/media-queries.ts
@@ -1,62 +1,139 @@
-import { breakpoints, tweakpoints } from "./theme";
+import { tweakpoints, breakpoints } from "./theme"
 
-// a helper type used for defining arguments passed to the `mq()` function
-// https://stackoverflow.com/a/49725198/2118700
-type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<
-	T,
-	Exclude<keyof T, Keys>
-> &
-	{
-		[K in Keys]-?: Required<Pick<T, K>> &
-			Partial<Pick<T, Exclude<Keys, K>>>;
-	}[Keys];
-
-type MediaQuery =
-	| "mobileMedium"
-	| "mobileLandscape"
-	| "phablet"
-	| "tablet"
-	| "desktop"
-	| "leftCol"
-	| "wide";
-
-const tweakAndBreakpoints = tweakpoints.concat(breakpoints);
-
-const mediaQueryMinimums: { [mediaQuery in MediaQuery]: number } = {
-	mobileMedium: tweakAndBreakpoints[0],
-	mobileLandscape: tweakAndBreakpoints[1],
-	phablet: tweakAndBreakpoints[2],
-	tablet: tweakAndBreakpoints[3],
-	desktop: tweakAndBreakpoints[4],
-	leftCol: tweakAndBreakpoints[5],
-	wide: tweakAndBreakpoints[6]
-};
-
-const minWidth = (value: number) => `@media (min-width: ${value}px)`;
-const maxWidth = (value: number) => `@media (max-width: ${value - 1}px)`;
-const minWidthMaxWidth = (from: number, until: number) =>
-	`@media (min-width: ${`${from}px`}) and (max-width: ${`${until - 1}px`})`;
-
-interface MQArgs {
-	from: MediaQuery;
-	until: MediaQuery;
+const breakpointMap = {
+	mobileMedium: tweakpoints[0],
+	mobileLandscape: tweakpoints[1],
+	phablet: tweakpoints[2],
+	tablet: breakpoints[0],
+	desktop: breakpoints[1],
+	leftCol: breakpoints[2],
+	wide: breakpoints[3]
 }
 
-const mq = ({ from, until }: RequireAtLeastOne<MQArgs, "from" | "until">) => {
-	if (from && until) {
-		return minWidthMaxWidth(
-			mediaQueryMinimums[from],
-			mediaQueryMinimums[until]
-		);
-	}
-	if (from) {
-		return minWidth(mediaQueryMinimums[from]);
-	}
-	if (until) {
-		return maxWidth(mediaQueryMinimums[until]);
-	}
+const minWidth = (from: number): string => `@media (min-width: ${`${from}px`})`
 
-	return "";
-};
+const maxWidth = (until: number): string =>
+	`@media (max-width: ${`${until - 1}px`})`
 
-export { mq };
+const minWidthMaxWidth = (from: number, until: number): string =>
+	`@media (min-width: ${`${from}px`}) and (max-width: ${`${until - 1}px`})`
+
+// min-widths
+export const mobileMedium = minWidth(breakpointMap.mobileMedium) // MobileMedium breakpoint is 360
+export const mobileLandscape = minWidth(breakpointMap.mobileLandscape) // MobileLandscape breakpoint is 480
+export const phablet = minWidth(breakpointMap.phablet) // Phablet breakpoint is 660
+export const tablet = minWidth(breakpointMap.tablet) // Tablet breakpoint is 740
+export const desktop = minWidth(breakpointMap.desktop) // Desktop breakpoint is 980
+export const leftCol = minWidth(breakpointMap.leftCol) // leftCol breakpoint is 1140
+export const wide = minWidth(breakpointMap.wide) // Wide breakpoint is 1300
+
+// e.g. until.*
+export const until = {
+	mobileMedium: maxWidth(breakpointMap.mobileMedium),
+	mobileLandscape: maxWidth(breakpointMap.mobileLandscape),
+	phablet: maxWidth(breakpointMap.phablet),
+	tablet: maxWidth(breakpointMap.tablet),
+	desktop: maxWidth(breakpointMap.desktop),
+	leftCol: maxWidth(breakpointMap.leftCol),
+	wide: maxWidth(breakpointMap.wide)
+}
+
+// e.g. from.*.until.*
+export const from = {
+	mobileMedium: {
+		until: {
+			mobileLandscape: minWidthMaxWidth(
+				breakpointMap.mobileMedium,
+				breakpointMap.mobileLandscape
+			),
+			phablet: minWidthMaxWidth(
+				breakpointMap.mobileMedium,
+				breakpointMap.phablet
+			),
+			tablet: minWidthMaxWidth(
+				breakpointMap.mobileMedium,
+				breakpointMap.tablet
+			),
+			desktop: minWidthMaxWidth(
+				breakpointMap.mobileMedium,
+				breakpointMap.desktop
+			),
+			leftCol: minWidthMaxWidth(
+				breakpointMap.mobileMedium,
+				breakpointMap.leftCol
+			),
+			wide: minWidthMaxWidth(
+				breakpointMap.mobileMedium,
+				breakpointMap.wide
+			)
+		}
+	},
+	mobileLandscape: {
+		until: {
+			phablet: minWidthMaxWidth(
+				breakpointMap.mobileLandscape,
+				breakpointMap.phablet
+			),
+			tablet: minWidthMaxWidth(
+				breakpointMap.mobileLandscape,
+				breakpointMap.tablet
+			),
+			desktop: minWidthMaxWidth(
+				breakpointMap.mobileLandscape,
+				breakpointMap.desktop
+			),
+			leftCol: minWidthMaxWidth(
+				breakpointMap.mobileLandscape,
+				breakpointMap.leftCol
+			),
+			wide: minWidthMaxWidth(
+				breakpointMap.mobileLandscape,
+				breakpointMap.wide
+			)
+		}
+	},
+	phablet: {
+		until: {
+			tablet: minWidthMaxWidth(
+				breakpointMap.phablet,
+				breakpointMap.tablet
+			),
+			desktop: minWidthMaxWidth(
+				breakpointMap.phablet,
+				breakpointMap.desktop
+			),
+			leftCol: minWidthMaxWidth(
+				breakpointMap.phablet,
+				breakpointMap.leftCol
+			),
+			wide: minWidthMaxWidth(breakpointMap.phablet, breakpointMap.wide)
+		}
+	},
+	tablet: {
+		until: {
+			desktop: minWidthMaxWidth(
+				breakpointMap.tablet,
+				breakpointMap.desktop
+			),
+			leftCol: minWidthMaxWidth(
+				breakpointMap.tablet,
+				breakpointMap.leftCol
+			),
+			wide: minWidthMaxWidth(breakpointMap.tablet, breakpointMap.wide)
+		}
+	},
+	desktop: {
+		until: {
+			leftCol: minWidthMaxWidth(
+				breakpointMap.desktop,
+				breakpointMap.leftCol
+			),
+			wide: minWidthMaxWidth(breakpointMap.desktop, breakpointMap.wide)
+		}
+	},
+	leftCol: {
+		until: {
+			wide: minWidthMaxWidth(breakpointMap.leftCol, breakpointMap.wide)
+		}
+	}
+}

--- a/packages/foundations/media-queries.ts
+++ b/packages/foundations/media-queries.ts
@@ -1,4 +1,4 @@
-import { tweakpoints, breakpoints } from "./theme"
+import { tweakpoints, breakpoints } from "./theme";
 
 const breakpointMap = {
 	mobileMedium: tweakpoints[0],
@@ -8,15 +8,15 @@ const breakpointMap = {
 	desktop: breakpoints[1],
 	leftCol: breakpoints[2],
 	wide: breakpoints[3]
-}
+};
 
-const minWidth = (from: number): string => `@media (min-width: ${`${from}px`})`
+const minWidth = (from: number): string => `@media (min-width: ${`${from}px`})`;
 
 const maxWidth = (until: number): string =>
-	`@media (max-width: ${`${until - 1}px`})`
+	`@media (max-width: ${`${until - 1}px`})`;
 
 const minWidthMaxWidth = (from: number, until: number): string =>
-	`@media (min-width: ${`${from}px`}) and (max-width: ${`${until - 1}px`})`
+	`@media (min-width: ${`${from}px`}) and (max-width: ${`${until - 1}px`})`;
 
 // e.g. until.*
 const until = {
@@ -27,7 +27,7 @@ const until = {
 	desktop: maxWidth(breakpointMap.desktop),
 	leftCol: maxWidth(breakpointMap.leftCol),
 	wide: maxWidth(breakpointMap.wide)
-}
+};
 
 // e.g. from.*.until.*
 const from = {
@@ -127,14 +127,14 @@ const from = {
 			wide: minWidthMaxWidth(breakpointMap.leftCol, breakpointMap.wide)
 		}
 	}
-}
+};
 
 // e.g. from.*
-from.mobileMedium.toString = () => minWidth(breakpointMap.mobileMedium)
-from.mobileLandscape.toString = () => minWidth(breakpointMap.mobileLandscape)
-from.phablet.toString = () => minWidth(breakpointMap.phablet)
-from.tablet.toString = () => minWidth(breakpointMap.tablet)
-from.desktop.toString = () => minWidth(breakpointMap.desktop)
-from.leftCol.toString = () => minWidth(breakpointMap.leftCol)
+from.mobileMedium.toString = () => minWidth(breakpointMap.mobileMedium);
+from.mobileLandscape.toString = () => minWidth(breakpointMap.mobileLandscape);
+from.phablet.toString = () => minWidth(breakpointMap.phablet);
+from.tablet.toString = () => minWidth(breakpointMap.tablet);
+from.desktop.toString = () => minWidth(breakpointMap.desktop);
+from.leftCol.toString = () => minWidth(breakpointMap.leftCol);
 
-export { from, until }
+export { from, until };

--- a/packages/foundations/package.json
+++ b/packages/foundations/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-foundations",
-	"version": "0.0.14",
+	"version": "0.1.0",
 	"main": "dist/foundations.js",
 	"module": "dist/foundations.esm.js",
 	"scripts": {

--- a/packages/foundations/package.json
+++ b/packages/foundations/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-foundations",
-	"version": "0.0.13",
+	"version": "0.0.14",
 	"main": "dist/foundations.js",
 	"module": "dist/foundations.esm.js",
 	"scripts": {

--- a/packages/foundations/package.json
+++ b/packages/foundations/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-foundations",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"main": "dist/foundations.js",
 	"module": "dist/foundations.esm.js",
 	"scripts": {

--- a/packages/foundations/space.ts
+++ b/packages/foundations/space.ts
@@ -8,7 +8,7 @@ const space = {
 	4: _space[4],
 	6: _space[5],
 	8: _space[6],
-	16: _space[7],
+	16: _space[7]
 };
 
 export { space };


### PR DESCRIPTION
A more consistent syntax, with a smaller API surface area:

```js
// before
${mobileLandscape} {

}

// after
${from.mobileLandscape} {

}
```