### PR TITLE
Restore old mq API

### DIFF
--- a/packages/foundations/media-queries.ts
+++ b/packages/foundations/media-queries.ts
@@ -129,12 +129,21 @@ const from = {
 	}
 };
 
-// e.g. from.*
-from.mobileMedium.toString = () => minWidth(breakpointMap.mobileMedium);
-from.mobileLandscape.toString = () => minWidth(breakpointMap.mobileLandscape);
-from.phablet.toString = () => minWidth(breakpointMap.phablet);
-from.tablet.toString = () => minWidth(breakpointMap.tablet);
-from.desktop.toString = () => minWidth(breakpointMap.desktop);
-from.leftCol.toString = () => minWidth(breakpointMap.leftCol);
+// min-widths
+const mobileMedium = minWidth(breakpointMap.mobileMedium);
+const mobileLandscape = minWidth(breakpointMap.mobileLandscape);
+const phablet = minWidth(breakpointMap.phablet);
+const tablet = minWidth(breakpointMap.tablet);
+const desktop = minWidth(breakpointMap.desktop);
+const leftCol = minWidth(breakpointMap.leftCol);
 
-export { from, until };
+export {
+	from,
+	until,
+	mobileMedium,
+	mobileLandscape,
+	phablet,
+	tablet,
+	desktop,
+	leftCol
+};

--- a/packages/foundations/package.json
+++ b/packages/foundations/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-foundations",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"main": "dist/foundations.js",
 	"module": "dist/foundations.esm.js",
 	"scripts": {


### PR DESCRIPTION
Assuming `toString()` will be called in `css` tagged template literal is dangerous! Let's revert to using named exports for `min-width` media queries, and rethink the whole API at a later date