### PR TITLE
Dark mode toggle

### DIFF
--- a/.storybook/addons.ts
+++ b/.storybook/addons.ts
@@ -1,1 +1,2 @@
-import "@storybook/addon-backgrounds/register";
+import "@storybook/addon-backgrounds/register"
+import "@storybook/addon-links/register"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"@emotion/babel-preset-css-prop": "^10.0.14",
 		"@emotion/core": "^10.0.14",
 		"@storybook/addon-backgrounds": "^5.2.1",
+		"@storybook/addon-links": "^5.2.1",
 		"@storybook/react": "^5.2.1",
 		"@types/react": "^16.9.2",
 		"@types/storybook__react": "^4.0.2",

--- a/packages/button/stories.tsx
+++ b/packages/button/stories.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { css } from "@emotion/core"
 import { storiesOf } from "@storybook/react"
-import { storybookBackgrounds } from "@guardian/src-helpers"
+import { storybookBackgrounds, Toggle } from "@guardian/src-helpers"
 import { SvgCheckmark } from "@guardian/src-svgs"
 import { size } from "@guardian/src-foundations"
 import { Button } from "./button"
@@ -51,11 +51,16 @@ const flexStart = css`
 `
 
 stories
-	.add("priority", () => (
+	.add("priority light", () => (
 		<div css={flexStart}>
 			{priorityButtons.map((button, index) => (
 				<div key={index}>{button}</div>
 			))}
+			<Toggle
+				storyKind="Button"
+				storyName="priority"
+				selectedValue="light"
+			/>
 		</div>
 	))
 	.add(
@@ -74,12 +79,17 @@ stories
 		},
 	)
 	.add(
-		"priority in dark mode",
+		"priority dark",
 		() => (
 			<div css={flexStart}>
 				{priorityButtons.map((button, index) => (
 					<div key={index}>{button}</div>
 				))}
+				<Toggle
+					storyKind="Button"
+					selectedValue="dark"
+					storyName="priority"
+				/>
 			</div>
 		),
 		{

--- a/packages/button/stories.tsx
+++ b/packages/button/stories.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { css } from "@emotion/core"
 import { storiesOf } from "@storybook/react"
-import { storybookBackgrounds, Toggle } from "@guardian/src-helpers"
+import { storybookBackgrounds, BackgroundToggle } from "@guardian/src-helpers"
 import { SvgCheckmark } from "@guardian/src-svgs"
 import { size } from "@guardian/src-foundations"
 import { Button } from "./button"
@@ -50,13 +50,21 @@ const flexStart = css`
 	}
 `
 
+const spaceBetween = css`
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+`
+
 stories
 	.add("priority light", () => (
-		<div css={flexStart}>
-			{priorityButtons.map((button, index) => (
-				<div key={index}>{button}</div>
-			))}
-			<Toggle
+		<div css={spaceBetween}>
+			<div css={flexStart}>
+				{priorityButtons.map((button, index) => (
+					<div key={index}>{button}</div>
+				))}
+			</div>
+			<BackgroundToggle
 				storyKind="Button"
 				storyName="priority"
 				selectedValue="light"
@@ -81,11 +89,13 @@ stories
 	.add(
 		"priority dark",
 		() => (
-			<div css={flexStart}>
-				{priorityButtons.map((button, index) => (
-					<div key={index}>{button}</div>
-				))}
-				<Toggle
+			<div css={spaceBetween}>
+				<div css={flexStart}>
+					{priorityButtons.map((button, index) => (
+						<div key={index}>{button}</div>
+					))}
+				</div>
+				<BackgroundToggle
 					storyKind="Button"
 					selectedValue="dark"
 					storyName="priority"

--- a/packages/button/stories.tsx
+++ b/packages/button/stories.tsx
@@ -1,7 +1,10 @@
 import React from "react"
 import { css } from "@emotion/core"
 import { storiesOf } from "@storybook/react"
-import { storybookBackgrounds, BackgroundToggle } from "@guardian/src-helpers"
+import {
+	storybookBackgrounds,
+	WithBackgroundToggle,
+} from "@guardian/src-helpers"
 import { SvgCheckmark } from "@guardian/src-svgs"
 import { size } from "@guardian/src-foundations"
 import { Button } from "./button"
@@ -50,26 +53,19 @@ const flexStart = css`
 	}
 `
 
-const spaceBetween = css`
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-`
-
 stories
 	.add("priority light", () => (
-		<div css={spaceBetween}>
+		<WithBackgroundToggle
+			storyKind="Button"
+			storyName="priority"
+			selectedValue="light"
+		>
 			<div css={flexStart}>
 				{priorityButtons.map((button, index) => (
 					<div key={index}>{button}</div>
 				))}
 			</div>
-			<BackgroundToggle
-				storyKind="Button"
-				storyName="priority"
-				selectedValue="light"
-			/>
-		</div>
+		</WithBackgroundToggle>
 	))
 	.add(
 		"priority on dark blue",
@@ -89,18 +85,17 @@ stories
 	.add(
 		"priority dark",
 		() => (
-			<div css={spaceBetween}>
+			<WithBackgroundToggle
+				storyKind="Button"
+				storyName="priority"
+				selectedValue="dark"
+			>
 				<div css={flexStart}>
 					{priorityButtons.map((button, index) => (
 						<div key={index}>{button}</div>
 					))}
 				</div>
-				<BackgroundToggle
-					storyKind="Button"
-					selectedValue="dark"
-					storyName="priority"
-				/>
-			</div>
+			</WithBackgroundToggle>
 		),
 		{
 			backgrounds: [

--- a/packages/helpers/index.ts
+++ b/packages/helpers/index.ts
@@ -1,2 +1,2 @@
 export { storybookBackgrounds } from "./storybook-bg"
-export { Toggle } from "./storybook-bg-toggle"
+export { BackgroundToggle } from "./storybook-bg-toggle"

--- a/packages/helpers/index.ts
+++ b/packages/helpers/index.ts
@@ -1,11 +1,2 @@
-import { palette } from "@guardian/src-foundations"
-
-const storybookBackgrounds = {
-	light: { name: "light", value: palette.neutral[100] },
-	blue: { name: "blue", value: palette.brand.main },
-	dark: { name: "dark", value: palette.neutral[10] },
-}
-
-Object.freeze(storybookBackgrounds)
-
-export { storybookBackgrounds }
+export { storybookBackgrounds } from "./storybook-bg"
+export { Toggle } from "./storybook-bg-toggle"

--- a/packages/helpers/index.ts
+++ b/packages/helpers/index.ts
@@ -1,2 +1,2 @@
 export { storybookBackgrounds } from "./storybook-bg"
-export { BackgroundToggle } from "./storybook-bg-toggle"
+export { WithBackgroundToggle } from "./storybook-bg-toggle"

--- a/packages/helpers/storybook-bg-toggle.tsx
+++ b/packages/helpers/storybook-bg-toggle.tsx
@@ -1,0 +1,19 @@
+import { linkTo } from "@storybook/addon-links"
+
+export const Toggle = ({
+	storyKind,
+	storyName,
+	selectedValue,
+}: {
+	storyKind: string
+	storyName: string
+	selectedValue: string
+}) => (
+	<select
+		value={`${storyName} ${selectedValue}`}
+		onChange={linkTo(storyKind, e => e.currentTarget.value)}
+	>
+		<option value={`${storyName} light`}>Light</option>
+		<option value={`${storyName} dark`}>Dark</option>
+	</select>
+)

--- a/packages/helpers/storybook-bg-toggle.tsx
+++ b/packages/helpers/storybook-bg-toggle.tsx
@@ -1,5 +1,5 @@
 import { linkTo } from "@storybook/addon-links"
-import { ReactNode } from "react"
+import React, { ReactNode } from "react"
 import { css } from "@emotion/core"
 
 const spaceBetween = css`
@@ -23,7 +23,15 @@ export const WithBackgroundToggle = ({
 		{children}
 		<select
 			value={`${storyName} ${selectedValue}`}
-			onChange={linkTo(storyKind, e => e.currentTarget.value)}
+			onChange={linkTo(storyKind, (e: Event) => {
+				const target = e.currentTarget as HTMLSelectElement
+
+				if (!target) {
+					return ""
+				}
+
+				return target.value
+			})}
 		>
 			<option value={`${storyName} light`}>Light Mode</option>
 			<option value={`${storyName} dark`}>Dark Mode</option>

--- a/packages/helpers/storybook-bg-toggle.tsx
+++ b/packages/helpers/storybook-bg-toggle.tsx
@@ -1,6 +1,6 @@
 import { linkTo } from "@storybook/addon-links"
 
-export const Toggle = ({
+export const BackgroundToggle = ({
 	storyKind,
 	storyName,
 	selectedValue,
@@ -13,7 +13,7 @@ export const Toggle = ({
 		value={`${storyName} ${selectedValue}`}
 		onChange={linkTo(storyKind, e => e.currentTarget.value)}
 	>
-		<option value={`${storyName} light`}>Light</option>
-		<option value={`${storyName} dark`}>Dark</option>
+		<option value={`${storyName} light`}>Light Mode</option>
+		<option value={`${storyName} dark`}>Dark Mode</option>
 	</select>
 )

--- a/packages/helpers/storybook-bg-toggle.tsx
+++ b/packages/helpers/storybook-bg-toggle.tsx
@@ -1,19 +1,32 @@
 import { linkTo } from "@storybook/addon-links"
+import { ReactNode } from "react"
+import { css } from "@emotion/core"
 
-export const BackgroundToggle = ({
+const spaceBetween = css`
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+`
+
+export const WithBackgroundToggle = ({
 	storyKind,
 	storyName,
 	selectedValue,
+	children,
 }: {
 	storyKind: string
 	storyName: string
 	selectedValue: string
+	children: ReactNode
 }) => (
-	<select
-		value={`${storyName} ${selectedValue}`}
-		onChange={linkTo(storyKind, e => e.currentTarget.value)}
-	>
-		<option value={`${storyName} light`}>Light Mode</option>
-		<option value={`${storyName} dark`}>Dark Mode</option>
-	</select>
+	<div css={spaceBetween}>
+		{children}
+		<select
+			value={`${storyName} ${selectedValue}`}
+			onChange={linkTo(storyKind, e => e.currentTarget.value)}
+		>
+			<option value={`${storyName} light`}>Light Mode</option>
+			<option value={`${storyName} dark`}>Dark Mode</option>
+		</select>
+	</div>
 )

--- a/packages/helpers/storybook-bg.ts
+++ b/packages/helpers/storybook-bg.ts
@@ -1,0 +1,11 @@
+import { palette } from "@guardian/src-foundations"
+
+const storybookBackgrounds = {
+	light: { name: "light", value: palette.neutral[100] },
+	blue: { name: "blue", value: palette.brand.main },
+	dark: { name: "dark", value: palette.neutral[10] },
+}
+
+Object.freeze(storybookBackgrounds)
+
+export { storybookBackgrounds }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1212,6 +1212,20 @@
     react-lifecycles-compat "^3.0.4"
     react-select "^3.0.0"
 
+"@storybook/addon-links@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-5.2.1.tgz#ec1fc92ed4d840ba758f40167c752f48562a906f"
+  integrity sha512-N5f+lzai+ctHfzHoYWECYsg3lKGJuqhkVctro46fHSW7s/GB8+l78nDcV7hDjNEXDES8QN5C1fPYihatdgpSJA==
+  dependencies:
+    "@storybook/addons" "5.2.1"
+    "@storybook/core-events" "5.2.1"
+    "@storybook/router" "5.2.1"
+    common-tags "^1.8.0"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    prop-types "^15.7.2"
+    qs "^6.6.0"
+
 "@storybook/addons@5.2.1":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-5.2.1.tgz#6e52aa1fa2737e170fb675eb1fcceebd0a915a0b"


### PR DESCRIPTION
Adds a storybook helper, using `@storybook/addons-links`, that switches between dark and light mode variants of a story. Requires a bit of smart setup.

**TODO**
- documentation
- better styling
- fix type of in [`linkTo`](https://github.com/storybookjs/storybook/blob/master/addons/links/src/preview.ts#L30)