### PR TITLE
Hide toolbar by default

### DIFF
--- a/.storybook/config.ts
+++ b/.storybook/config.ts
@@ -1,8 +1,19 @@
-import { configure } from "@storybook/react";
+import { configure, addParameters } from "@storybook/react"
 
 function loadStories() {
-	require("../packages/button/stories.tsx");
-	require("../packages/radio/stories.tsx");
+	require("../packages/button/stories.tsx")
+	require("../packages/radio/stories.tsx")
 }
 
-configure(loadStories, module);
+// We hide the toolbar by default to make Storybook embeds
+// look nicer in Zeroheight. Related discussion:
+// https://github.com/storybookjs/storybook/issues/8129
+// https://spectrum.chat/zeroheight/feature-requests/swap-out-storybook-stories-in-situ~29d7760d-aba6-4bb3-bf4a-37c119dbc622
+
+addParameters({
+	options: {
+		isToolshown: false,
+	},
+})
+
+configure(loadStories, module)


### PR DESCRIPTION
The Storybook integration in Zeroheight relies on embedding `iframe.html` into the documentation page. This is not properly supported by Storybook, so things like addons (background, links) do not work.

To work around this Zeroheight recommend using the embed block to embed the full Storybook link in an iframe. This works, but brings all of Storybook's furniture (nav, addons panel, toolbar). Most of this can be turned off using URL params, but the toolbar needs to be hidden using configuration settings.

It would be great if Storybook would support hiding the Toolbar using a URL param. I'll see if they would be interested.