### PR TITLE
Make all stories fullscreen 😕

### DIFF
--- a/.storybook/config.ts
+++ b/.storybook/config.ts
@@ -13,6 +13,7 @@ function loadStories() {
 addParameters({
 	options: {
 		isToolshown: false,
+		isFullscreen: true,
 	},
 })
 


### PR DESCRIPTION
For now, we need to make stories appear full screen by default, for better integration with Zeroheight. 

This follows from #19. By updating the configuration in this way, it becomes impossible to use the `full=1` URL param to make the stories fullscreen. It's like the default config overrides the URL param.