### PR TITLE
Remove padding from low priority

### DIFF
--- a/packages/button/button.tsx
+++ b/packages/button/button.tsx
@@ -67,8 +67,8 @@ const Button = ({
 		<button
 			css={[
 				button,
-				priorities[priority],
 				sizes[size],
+				priorities[priority],
 				iconSvg ? icon : "",
 				iconSide ? iconSides[iconSide] : "",
 				!children ? iconOnlySizes[size] : "",

--- a/packages/button/stories.tsx
+++ b/packages/button/stories.tsx
@@ -12,17 +12,20 @@ import { Button } from "./button"
 const stories = storiesOf("Button", module)
 /* eslint-disable react/jsx-key */
 const priorityButtons = [
-	<Button>High</Button>,
-	<Button priority="moderate">Moderate</Button>,
-	<Button priority="low">Low</Button>,
+	<Button>High priority</Button>,
+	<Button priority="moderate">Moderate priority</Button>,
+	<Button priority="low">Low priority</Button>,
 ]
-const sizeButtons = [<Button>High</Button>, <Button size="small">Small</Button>]
+const sizeButtons = [
+	<Button>Default</Button>,
+	<Button size="small">Small</Button>,
+]
 const textIconButtons = [
 	<Button iconSide="left" icon={<SvgCheckmark />}>
-		Button Label
+		Left aligned
 	</Button>,
 	<Button iconSide="right" icon={<SvgCheckmark />}>
-		Button Label
+		Right aligned
 	</Button>,
 ]
 const iconButtons = [

--- a/packages/button/styles.ts
+++ b/packages/button/styles.ts
@@ -47,9 +47,10 @@ export const moderatePriority = css`
 export const lowPriority = css`
 	background-color: ${palette.neutral[100]};
 	color: ${palette.neutral[7]};
+	padding: 0;
 
 	&:hover {
-		background-color: ${palette.neutral[93]};
+		text-decoration: underline;
 	}
 `
 


### PR DESCRIPTION
- removes padding from low priority buttons, to improve visual alignment with form elements above and below
- on hover, low priority gets underline, no background colour change
- reorders button classes: `size` styles come first and are overridden by styles in `priority`
- better button labels