### PR TITLE
Make stories fullscreen in prod

### DIFF
--- a/.storybook/config.ts
+++ b/.storybook/config.ts
@@ -1,5 +1,7 @@
 import { configure, addParameters } from "@storybook/react"
 
+const storiesOnly = process.env.NODE_ENV === "production"
+
 function loadStories() {
 	require("../packages/button/stories.tsx")
 	require("../packages/radio/stories.tsx")
@@ -13,8 +15,8 @@ function loadStories() {
 
 addParameters({
 	options: {
-		isToolshown: false,
-		isFullscreen: true,
+		isToolshown: !storiesOnly,
+		isFullscreen: storiesOnly,
 	},
 })
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"build:svgs": "cd packages/svgs && yarn build",
 		"build:button": "cd packages/button && yarn build",
 		"build:radio": "cd packages/radio && yarn build",
-		"build": "yarn build:storybook && yarn build:foundations && yarn build:svgs && yarn build:button && yarn build:radio",
+		"build": "NODE_ENV=production yarn build:storybook && yarn build:foundations && yarn build:svgs && yarn build:button && yarn build:radio",
 		"deploy": "yarn build && gh-pages -d dist"
 	},
 	"private": true,


### PR DESCRIPTION
Currently stories are always fullscreen (see #20 #19)

This change makes them fullscreen only in production.