### PR TITLE
Add 'wide' Media Query

### DIFF
--- a/packages/foundations/media-queries.ts
+++ b/packages/foundations/media-queries.ts
@@ -136,6 +136,7 @@ const phablet = minWidth(breakpointMap.phablet)
 const tablet = minWidth(breakpointMap.tablet)
 const desktop = minWidth(breakpointMap.desktop)
 const leftCol = minWidth(breakpointMap.leftCol)
+const wide = minWidth(breakpointMap.wide)
 
 export {
 	from,
@@ -146,4 +147,5 @@ export {
 	tablet,
 	desktop,
 	leftCol,
+	wide,
 }

--- a/packages/foundations/package.json
+++ b/packages/foundations/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-foundations",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"main": "dist/foundations.js",
 	"module": "dist/foundations.esm.js",
 	"scripts": {


### PR DESCRIPTION
## Why?

We'd like to make use of a "from wide" media query on apps-rendering, where we're using the `src-foundations` package.

## Changes

- Added and exported a "min-width" wide media query to src-foundations.
