### PR TITLE
Remove 'from' From Docs

### DIFF
--- a/packages/foundations/README.md
+++ b/packages/foundations/README.md
@@ -28,10 +28,6 @@ import { from, until } from "@guardian/src-foundations"
 const styles = css`
 	padding: 0 10px;
 
-	${from.mobileLandscape} {
-		padding: 0 20px;
-	}
-
 	${from.phablet.until.desktop} {
 		padding: 0 32px;
 	}

--- a/packages/foundations/README.md
+++ b/packages/foundations/README.md
@@ -23,10 +23,14 @@ const backgroundColour = css`
 ### [Media queries](https://zeroheight.com/2a1e5182b/p/14af24)
 
 ```ts
-import { from, until } from "@guardian/src-foundations"
+import { mobileLandscape, from, until } from "@guardian/src-foundations"
 
 const styles = css`
 	padding: 0 10px;
+
+    ${mobileLandscape} {		
+ 		padding: 0 20px;		
+ 	}
 
 	${from.phablet.until.desktop} {
 		padding: 0 32px;


### PR DESCRIPTION
## Why?

This is not functionality currently supported by `from` as far as I'm aware.

## Changes

- Removed unimplemented example of `from` from the docs.
