### PR TITLE
Support boolean error flag on radio group

### DIFF
--- a/packages/radio/radio.tsx
+++ b/packages/radio/radio.tsx
@@ -75,12 +75,12 @@ const RadioGroup = ({
 	name: string
 	appearance: Appearance
 	orientation: Orientation
-	error?: string
+	error?: boolean | string
 	children: ReactNode
 }) => {
 	return (
 		<div css={[group, orientationStyles[orientation]]} {...props}>
-			{error && <InlineError>{error}</InlineError>}
+			{typeof error === "string" && <InlineError>{error}</InlineError>}
 			{React.Children.map(children, child => {
 				if (!React.isValidElement(child)) {
 					// Consumer is probably passing a text node as a child

--- a/packages/radio/stories.tsx
+++ b/packages/radio/stories.tsx
@@ -135,9 +135,9 @@ errorWithMessage.story = {
 }
 
 const errorWithoutMessage = () => (
-	<RadioGroup name="colours">
+	<RadioGroup name="colours" error={true}>
 		{unselectedRadios.map((radio, index) =>
-			React.cloneElement(radio, { key: index, error: true }),
+			React.cloneElement(radio, { key: index }),
 		)}
 	</RadioGroup>
 )


### PR DESCRIPTION
Allows us to pass a boolean as an error prop to `RadioGroup`. It is not always necessary to show an error message