### PR TITLE
Expose breakpointMap

### DIFF
--- a/packages/foundations/media-queries.ts
+++ b/packages/foundations/media-queries.ts
@@ -148,5 +148,5 @@ export {
 	desktop,
 	leftCol,
 	wide,
-	breakpointMap,
+	breakpointMap as breakpoints,
 }

--- a/packages/foundations/media-queries.ts
+++ b/packages/foundations/media-queries.ts
@@ -148,4 +148,5 @@ export {
 	desktop,
 	leftCol,
 	wide,
+	breakpointMap,
 }


### PR DESCRIPTION
## Why?

We'd like to access the breakpoint values directly on apps, as we've currently got a magic number in our CSS: `width: 1300px`. In the past it's been useful to reference breakpoint widths by name in situations like this, to make the CSS clearer.

@SiAdcock @zeftilldeath is this:

1. Something that you're ok for the design system to do?
2. The correct place to be exposing this?

## Changes

- Exposed a map of the seven breakpoints `{ [name]: numericValue }` from `media-queries`.
