### PR TITLE
Add utilities package exposing media queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "source-components",
 	"version": "0.0.1",
 	"scripts": {
-		"storybook": "yarn watch:foundations & yarn watch:svgs & start-storybook",
+		"storybook": "yarn watch:foundations & watch:utilities & yarn watch:svgs & start-storybook",
 		"lint:styles": "stylelint packages/**/styles.ts",
 		"lint:js": "eslint . --ext .ts,.tsx",
 		"lint": "yarn lint:js && yarn lint:styles",
@@ -12,12 +12,14 @@
 		"build:storybook": "build-storybook -o dist",
 		"build:foundations": "cd packages/foundations && yarn build",
 		"watch:foundations": "cd packages/foundations && yarn watch",
+		"build:utilities": "cd packages/utilities && yarn build",
+		"watch:utilities": "cd packages/utilities && yarn watch",
 		"watch:svgs": "cd packages/svgs && yarn watch",
 		"build:svgs": "cd packages/svgs && yarn build",
 		"build:button": "cd packages/button && yarn build",
 		"build:inline-error": "cd packages/inline-error && yarn build",
 		"build:radio": "cd packages/radio && yarn build",
-		"build": "NODE_ENV=production yarn build:storybook && yarn build:foundations && yarn build:svgs && yarn build:button && yarn build:inline-error && yarn build:radio"
+		"build": "NODE_ENV=production yarn build:storybook && yarn build:foundations && yarn build:utilities && yarn build:svgs && yarn build:button && yarn build:inline-error && yarn build:radio"
 	},
 	"private": true,
 	"workspaces": [

--- a/packages/utilities/.babelrc.js
+++ b/packages/utilities/.babelrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+	presets: ["@babel/preset-env", "@babel/preset-typescript"]
+};

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -1,0 +1,1 @@
+# Utilities

--- a/packages/utilities/index.ts
+++ b/packages/utilities/index.ts
@@ -1,0 +1,1 @@
+export * from "./media-queries"

--- a/packages/utilities/media-queries.ts
+++ b/packages/utilities/media-queries.ts
@@ -1,0 +1,112 @@
+import { breakpoints } from "@guardian/src-foundations"
+
+const minWidth = (from: number): string => `@media (min-width: ${`${from}px`})`
+
+const maxWidth = (until: number): string =>
+	`@media (max-width: ${`${until - 1}px`})`
+
+const minWidthMaxWidth = (from: number, until: number): string =>
+	`@media (min-width: ${`${from}px`}) and (max-width: ${`${until - 1}px`})`
+
+// e.g. from.*
+const from = {
+	mobileMedium: minWidth(breakpoints.mobileMedium),
+	mobileLandscape: minWidth(breakpoints.mobileLandscape),
+	phablet: minWidth(breakpoints.phablet),
+	tablet: minWidth(breakpoints.tablet),
+	desktop: minWidth(breakpoints.desktop),
+	leftCol: minWidth(breakpoints.leftCol),
+	wide: minWidth(breakpoints.wide),
+}
+
+// e.g. until.*
+const until = {
+	mobileMedium: maxWidth(breakpoints.mobileMedium),
+	mobileLandscape: maxWidth(breakpoints.mobileLandscape),
+	phablet: maxWidth(breakpoints.phablet),
+	tablet: maxWidth(breakpoints.tablet),
+	desktop: maxWidth(breakpoints.desktop),
+	leftCol: maxWidth(breakpoints.leftCol),
+	wide: maxWidth(breakpoints.wide),
+}
+
+// e.g. between.*.and.*
+const between = {
+	mobileMedium: {
+		and: {
+			mobileLandscape: minWidthMaxWidth(
+				breakpoints.mobileMedium,
+				breakpoints.mobileLandscape,
+			),
+			phablet: minWidthMaxWidth(
+				breakpoints.mobileMedium,
+				breakpoints.phablet,
+			),
+			tablet: minWidthMaxWidth(
+				breakpoints.mobileMedium,
+				breakpoints.tablet,
+			),
+			desktop: minWidthMaxWidth(
+				breakpoints.mobileMedium,
+				breakpoints.desktop,
+			),
+			leftCol: minWidthMaxWidth(
+				breakpoints.mobileMedium,
+				breakpoints.leftCol,
+			),
+			wide: minWidthMaxWidth(breakpoints.mobileMedium, breakpoints.wide),
+		},
+	},
+	mobileLandscape: {
+		and: {
+			phablet: minWidthMaxWidth(
+				breakpoints.mobileLandscape,
+				breakpoints.phablet,
+			),
+			tablet: minWidthMaxWidth(
+				breakpoints.mobileLandscape,
+				breakpoints.tablet,
+			),
+			desktop: minWidthMaxWidth(
+				breakpoints.mobileLandscape,
+				breakpoints.desktop,
+			),
+			leftCol: minWidthMaxWidth(
+				breakpoints.mobileLandscape,
+				breakpoints.leftCol,
+			),
+			wide: minWidthMaxWidth(
+				breakpoints.mobileLandscape,
+				breakpoints.wide,
+			),
+		},
+	},
+	phablet: {
+		and: {
+			tablet: minWidthMaxWidth(breakpoints.phablet, breakpoints.tablet),
+			desktop: minWidthMaxWidth(breakpoints.phablet, breakpoints.desktop),
+			leftCol: minWidthMaxWidth(breakpoints.phablet, breakpoints.leftCol),
+			wide: minWidthMaxWidth(breakpoints.phablet, breakpoints.wide),
+		},
+	},
+	tablet: {
+		and: {
+			desktop: minWidthMaxWidth(breakpoints.tablet, breakpoints.desktop),
+			leftCol: minWidthMaxWidth(breakpoints.tablet, breakpoints.leftCol),
+			wide: minWidthMaxWidth(breakpoints.tablet, breakpoints.wide),
+		},
+	},
+	desktop: {
+		and: {
+			leftCol: minWidthMaxWidth(breakpoints.desktop, breakpoints.leftCol),
+			wide: minWidthMaxWidth(breakpoints.desktop, breakpoints.wide),
+		},
+	},
+	leftCol: {
+		and: {
+			wide: minWidthMaxWidth(breakpoints.leftCol, breakpoints.wide),
+		},
+	},
+}
+
+export { from, until, between, breakpoints }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@guardian/src-utilities",
+  "version": "0.1.0",
+  "main": "dist/utilities.js",
+  "module": "dist/utilities.esm.js",
+  "scripts": {
+    "build": "rollup --config",
+    "watch": "rollup --config --watch",
+    "clean": "rm -rf dist",
+    "prepublish": "yarn build"
+  },
+  "files": [
+    "dist/**/*.js",
+    "index.ts",
+    "media-queries.ts"
+  ],
+  "devDependencies": {
+    "@babel/preset-env": "^7.5.5",
+    "@babel/preset-typescript": "^7.3.3",
+    "@guardian/src-foundations": "^0.2.3",
+    "rollup": "^1.19.4",
+    "rollup-plugin-babel": "^4.3.3",
+    "rollup-plugin-node-resolve": "^5.2.0"
+  },
+  "peerDependencies": {
+    "@guardian/src-foundations": "^0.2.3"
+  }
+}

--- a/packages/utilities/rollup.config.js
+++ b/packages/utilities/rollup.config.js
@@ -1,0 +1,19 @@
+import babel from "rollup-plugin-babel"
+import resolve from "rollup-plugin-node-resolve"
+
+const extensions = [".ts", ".tsx"]
+
+module.exports = {
+	input: "index.ts",
+	output: [
+		{
+			file: "dist/utilities.js",
+			format: "cjs",
+		},
+		{
+			file: "dist/utilities.esm.js",
+			format: "esm",
+		},
+	],
+	plugins: [babel({ extensions }), resolve({ extensions })],
+}


### PR DESCRIPTION
## What does this change?

- moves media-queries module over to `@guardian/src-utilities`
- makes breaking change to the media-queries API (note this will not affect the media-queries module in `@guardian/src-foundations`)

## Previous API (still exposed in `@guardian/src-foundations`)

```js
import {tablet, until, from} from '@guardian/src-foundations'

const wider = css`
  ${tablet} {...}
`

const narrower = css`
  ${until.desktop} {...}
`

const middle = css`
  ${from.tablet.until.desktop} {...}
`
```

## New API

```js
import {tablet, until, from} from '@guardian/src-utilities'

const wider = css`
  ${from.tablet} {...}
`

const narrower = css`
  ${until.desktop} {...}
`

const middle = css`
  ${between.tablet.and.desktop} {...}
`
```

## Why?

- There were issues when developers tried using `from.x`, which returns an object and fails silently in Emotion. `from` may only be used in conjunction with `until`, but this is not clear.
- Using `between` implies there must be an `and`

## Todo

- deprecate old media-queries module in `@guardian/src-foundations`

## Big thanks 🤗 

@oliverlloyd @sndrs @nicl 

## Replaces: #50