### PR TITLE
Better docs for foundations and utilities

### DIFF
--- a/packages/foundations/README.md
+++ b/packages/foundations/README.md
@@ -69,3 +69,34 @@ Output:
     }
 }
 ```
+
+### Visually Hidden
+
+**_DEPRECATED!_** Please import `visuallyHidden` from [`@guardian/src-utilities`](https://github.com/guardian/source-components/tree/master/packages/utilities#visually-hidden)
+
+For elements that should not appear to sighted users, but are useful to assistive technology users.
+
+```ts
+import { visuallyHidden } from "@guardian/src-foundations"
+
+const label = css`
+    ${visuallyHidden};
+`
+```
+
+### Focus Halo
+
+**_DEPRECATED!_** Please import `focusHalo` from [`@guardian/src-utilities`](https://github.com/guardian/source-components/tree/master/packages/utilities#focus-halo)
+
+This mixin provides a [clear focus state](https://zeroheight.com/2a1e5182b/p/08dc26/t/314e46) for
+elements that may receive keyboard focus.
+
+```ts
+import { focusHalo } from "@guardian/src-foundations"
+
+const input = css`
+    ${focusHalo};
+    width: 200px;
+    height: 44px;
+`
+```

--- a/packages/foundations/README.md
+++ b/packages/foundations/README.md
@@ -16,29 +16,31 @@ $ yarn add @guardian/src-foundations
 import { palette } from "@guardian/src-foundations"
 
 const backgroundColor = css`
-	background-color: ${palette.neutral[97]};
+    background-color: ${palette.neutral[97]};
 `
 ```
 
-### [Media queries](https://zeroheight.com/2a1e5182b/p/14af24)
+### Media queries
+
+**_DEPRECATED!_** Please import media queries from [`@guardian/src-utilities`](https://github.com/guardian/source-components/tree/master/packages/utilities#media-queries)
 
 ```ts
 import { mobileLandscape, from, until } from "@guardian/src-foundations"
 
 const styles = css`
-	padding: 0 10px;
+    padding: 0 10px;
 
-	${mobileLandscape} {
-		padding: 0 20px;
-	}
+    ${mobileLandscape} {
+        padding: 0 20px;
+    }
 
-	${from.phablet.until.desktop} {
-		padding: 0 32px;
-	}
+    ${from.phablet.until.desktop} {
+        padding: 0 32px;
+    }
 
-	${until.wide} {
-		padding: 0 40px;
-	}
+    ${until.wide} {
+        padding: 0 40px;
+    }
 `
 ```
 
@@ -46,24 +48,24 @@ Output:
 
 ```css
 .class-name {
-	padding: 0 10px;
+    padding: 0 10px;
 }
 
 @media (min-width: 480px) {
-	.class-name {
-		padding: 0 20px;
-	}
+    .class-name {
+        padding: 0 20px;
+    }
 }
 
 @media (min-width: 660px) and (max-width: 980px) {
-	.class-name {
-		padding: 0 32px;
-	}
+    .class-name {
+        padding: 0 32px;
+    }
 }
 
 @media (max-width: 1300px) {
-	.class-name {
-		padding: 0 40px;
-	}
+    .class-name {
+        padding: 0 40px;
+    }
 }
 ```

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -58,3 +58,30 @@ Output:
     }
 }
 ```
+
+### Visually Hidden
+
+For elements that should not appear to sighted users, but are useful to assistive technology users.
+
+```ts
+import { visuallyHidden } from "@guardian/src-utilities"
+
+const label = css`
+    ${visuallyHidden};
+`
+```
+
+### Focus Halo
+
+This mixin provides a [clear focus state](https://zeroheight.com/2a1e5182b/p/08dc26/t/314e46) for
+elements that may receive keyboard focus.
+
+```ts
+import { focusHalo } from "@guardian/src-utilities"
+
+const input = css`
+    ${focusHalo};
+    width: 200px;
+    height: 44px;
+`
+```

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -1,1 +1,60 @@
 # Utilities
+
+reusable style snippets for the web, or functions that you may find useful. Style snippets are expressed as template strings,
+and should be compatible with any CSS-in-JS library that accepts this notation.
+
+## Install
+
+```sh
+$ yarn add @guardian/src-utilities
+```
+
+## Use
+
+### Media queries
+
+```ts
+import { from, until, between } from "@guardian/src-utilities"
+
+const styles = css`
+    padding: 0 10px;
+
+    ${from.mobileLandscape} {
+        padding: 0 20px;
+    }
+
+    ${between.phablet.and.desktop} {
+        padding: 0 32px;
+    }
+
+    ${until.wide} {
+        padding: 0 40px;
+    }
+`
+```
+
+Output:
+
+```css
+.class-name {
+    padding: 0 10px;
+}
+
+@media (min-width: 480px) {
+    .class-name {
+        padding: 0 20px;
+    }
+}
+
+@media (min-width: 660px) and (max-width: 980px) {
+    .class-name {
+        padding: 0 32px;
+    }
+}
+
+@media (max-width: 1300px) {
+    .class-name {
+        padding: 0 40px;
+    }
+}
+```

--- a/packages/utilities/helpers.ts
+++ b/packages/utilities/helpers.ts
@@ -1,0 +1,19 @@
+import { palette } from "@guardian/src-foundations"
+
+const visuallyHidden = `
+	position: absolute;
+	opacity: 0;
+	height: 0;
+	width: 0;
+	top: 0;
+	left: 0;
+`
+
+// TODO: migrate to using context-specific alias
+const focusHalo = `
+	outline: 0;
+	box-shadow: 0 0 0 5px ${palette.sport.bright};
+	z-index: 9;
+`
+
+export { visuallyHidden, focusHalo }

--- a/packages/utilities/index.ts
+++ b/packages/utilities/index.ts
@@ -1,1 +1,2 @@
+export * from "./helpers"
 export * from "./media-queries"

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,28 +1,29 @@
 {
-  "name": "@guardian/src-utilities",
-  "version": "0.1.0",
-  "main": "dist/utilities.js",
-  "module": "dist/utilities.esm.js",
-  "scripts": {
-    "build": "rollup --config",
-    "watch": "rollup --config --watch",
-    "clean": "rm -rf dist",
-    "prepublish": "yarn build"
-  },
-  "files": [
-    "dist/**/*.js",
-    "index.ts",
-    "media-queries.ts"
-  ],
-  "devDependencies": {
-    "@babel/preset-env": "^7.5.5",
-    "@babel/preset-typescript": "^7.3.3",
-    "@guardian/src-foundations": "^0.2.3",
-    "rollup": "^1.19.4",
-    "rollup-plugin-babel": "^4.3.3",
-    "rollup-plugin-node-resolve": "^5.2.0"
-  },
-  "peerDependencies": {
-    "@guardian/src-foundations": "^0.2.3"
-  }
+	"name": "@guardian/src-utilities",
+	"version": "0.1.0",
+	"main": "dist/utilities.js",
+	"module": "dist/utilities.esm.js",
+	"scripts": {
+		"build": "rollup --config",
+		"watch": "rollup --config --watch",
+		"clean": "rm -rf dist",
+		"prepublish": "yarn build"
+	},
+	"files": [
+		"dist/**/*.js",
+		"index.ts",
+		"helpers.ts",
+		"media-queries.ts"
+	],
+	"devDependencies": {
+		"@babel/preset-env": "^7.5.5",
+		"@babel/preset-typescript": "^7.3.3",
+		"@guardian/src-foundations": "^0.2.3",
+		"rollup": "^1.19.4",
+		"rollup-plugin-babel": "^4.3.3",
+		"rollup-plugin-node-resolve": "^5.2.0"
+	},
+	"peerDependencies": {
+		"@guardian/src-foundations": "^0.2.3"
+	}
 }


### PR DESCRIPTION
- moved media queries docs to utilities
- moved visuallyHidden docs to utilities
- moved focusHalo docs to utilities
- deprecated media queries, visuallyHidden and focusHalo in foundations