### PR TITLE
Use slightly correcter fonts

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,357 @@
+<style>
+	/* BEGIN HEADLINE */
+
+	@font-face {
+		font-family: "GH Guardian Headline";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Light.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Light.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Light.ttf")
+				format("truetype");
+		font-weight: 300;
+		font-style: normal;
+	}
+
+	@font-face {
+		font-family: "GH Guardian Headline";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-LightItalic.ttf")
+				format("truetype");
+		font-weight: 300;
+		font-style: italic;
+	}
+
+	@font-face {
+		font-family: "GH Guardian Headline";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Regular.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Regular.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Regular.ttf")
+				format("truetype");
+		font-weight: 400;
+		font-style: normal;
+	}
+
+	@font-face {
+		font-family: "GH Guardian Headline";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-RegularItalic.ttf")
+				format("truetype");
+		font-weight: 400;
+		font-style: italic;
+	}
+
+	@font-face {
+		font-family: "GH Guardian Headline";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Medium.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Medium.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Medium.ttf")
+				format("truetype");
+		font-weight: 500;
+		font-style: normal;
+	}
+
+	@font-face {
+		font-family: "GH Guardian Headline";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-MediumItalic.ttf")
+				format("truetype");
+		font-weight: 500;
+		font-style: italic;
+	}
+
+	@font-face {
+		font-family: "GH Guardian Headline";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Semibold.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Semibold.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Semibold.ttf")
+				format("truetype");
+		font-weight: 600;
+		font-style: normal;
+	}
+
+	@font-face {
+		font-family: "GH Guardian Headline";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.ttf")
+				format("truetype");
+		font-weight: 600;
+		font-style: italic;
+	}
+
+	@font-face {
+		font-family: "GH Guardian Headline";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Bold.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Bold.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Bold.ttf")
+				format("truetype");
+		font-weight: 700;
+		font-style: normal;
+	}
+
+	@font-face {
+		font-family: "GH Guardian Headline";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BoldItalic.ttf")
+				format("truetype");
+		font-weight: 700;
+		font-style: italic;
+	}
+
+	@font-face {
+		font-family: "GH Guardian Headline";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Black.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Black.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Black.ttf")
+				format("truetype");
+		font-weight: 900;
+		font-style: normal;
+	}
+
+	@font-face {
+		font-family: "GH Guardian Headline";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BlackItalic.ttf")
+				format("truetype");
+		font-weight: 900;
+		font-style: italic;
+	}
+
+	/* BEGIN TEXT SANS */
+
+	@font-face {
+		font-family: "GuardianTextSans";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Regular.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Regular.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Regular.ttf")
+				format("truetype");
+		font-weight: 400;
+		font-style: normal;
+	}
+
+	@font-face {
+		font-family: "GuardianTextSans";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-RegularItalic.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-RegularItalic.ttf")
+				format("truetype");
+		font-weight: 400;
+		font-style: italic;
+	}
+
+	@font-face {
+		font-family: "GuardianTextSans";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Medium.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Medium.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Medium.ttf")
+				format("truetype");
+		font-weight: 500;
+		font-style: normal;
+	}
+
+	@font-face {
+		font-family: "GuardianTextSans";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-MediumItalic.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-MediumItalic.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-MediumItalic.ttf")
+				format("truetype");
+		font-weight: 500;
+		font-style: italic;
+	}
+
+	@font-face {
+		font-family: "GuardianTextSans";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Bold.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Bold.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Bold.ttf")
+				format("truetype");
+		font-weight: 700;
+		font-style: normal;
+	}
+
+	@font-face {
+		font-family: "GuardianTextSans";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-BoldItalic.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-BoldItalic.ttf")
+				format("truetype");
+		font-weight: 700;
+		font-style: italic;
+	}
+
+	@font-face {
+		font-family: "GuardianTextSans";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Black.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Black.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Black.ttf")
+				format("truetype");
+		font-weight: 900;
+		font-style: normal;
+	}
+
+	@font-face {
+		font-family: "GuardianTextSans";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-BlackItalic.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-BlackItalic.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-BlackItalic.ttf")
+				format("truetype");
+		font-weight: 900;
+		font-style: italic;
+	}
+
+	/* BEGIN TEXT EGYPTIAN */
+
+	@font-face {
+		font-family: "GuardianTextEgyptian";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Regular.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Regular.ttf")
+				format("truetype");
+		font-weight: 400;
+		font-style: normal;
+	}
+
+	@font-face {
+		font-family: "GuardianTextEgyptian";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.ttf")
+				format("truetype");
+		font-weight: 400;
+		font-style: italic;
+	}
+
+	@font-face {
+		font-family: "GuardianTextEgyptian";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Medium.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Medium.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Medium.ttf")
+				format("truetype");
+		font-weight: 500;
+		font-style: normal;
+	}
+
+	@font-face {
+		font-family: "GuardianTextEgyptian";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.ttf")
+				format("truetype");
+		font-weight: 500;
+		font-style: italic;
+	}
+
+	@font-face {
+		font-family: "GuardianTextEgyptian";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Bold.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Bold.ttf")
+				format("truetype");
+		font-weight: 700;
+		font-style: normal;
+	}
+
+	@font-face {
+		font-family: "GuardianTextEgyptian";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.ttf")
+				format("truetype");
+		font-weight: 700;
+		font-style: italic;
+	}
+
+	@font-face {
+		font-family: "GuardianTextEgyptian";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Black.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Black.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Black.ttf")
+				format("truetype");
+		font-weight: 900;
+		font-style: normal;
+	}
+
+	@font-face {
+		font-family: "GuardianTextEgyptian";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.ttf")
+				format("truetype");
+		font-weight: 900;
+		font-style: italic;
+	}
+
+	/* BEGIN TITLEPIECE */
+
+	@font-face {
+		font-family: "GT Guardian Titlepiece";
+		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff2")
+				format("woff2"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff")
+				format("woff"),
+			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.ttf")
+				format("truetype");
+		font-weight: 700;
+		font-style: normal;
+	}
+</style>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -149,11 +149,11 @@
 
 	@font-face {
 		font-family: "GuardianTextSans";
-		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Regular.woff2")
+		src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Regular.woff2")
 				format("woff2"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Regular.woff")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Regular.woff")
 				format("woff"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Regular.ttf")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Regular.ttf")
 				format("truetype");
 		font-weight: 400;
 		font-style: normal;
@@ -161,11 +161,11 @@
 
 	@font-face {
 		font-family: "GuardianTextSans";
-		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2")
+		src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-RegularItalic.woff2")
 				format("woff2"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-RegularItalic.woff")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-RegularItalic.woff")
 				format("woff"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-RegularItalic.ttf")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-RegularItalic.ttf")
 				format("truetype");
 		font-weight: 400;
 		font-style: italic;
@@ -173,11 +173,11 @@
 
 	@font-face {
 		font-family: "GuardianTextSans";
-		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Medium.woff2")
+		src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Medium.woff2")
 				format("woff2"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Medium.woff")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Medium.woff")
 				format("woff"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Medium.ttf")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Medium.ttf")
 				format("truetype");
 		font-weight: 500;
 		font-style: normal;
@@ -185,11 +185,11 @@
 
 	@font-face {
 		font-family: "GuardianTextSans";
-		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-MediumItalic.woff2")
+		src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-MediumItalic.woff2")
 				format("woff2"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-MediumItalic.woff")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-MediumItalic.woff")
 				format("woff"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-MediumItalic.ttf")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-MediumItalic.ttf")
 				format("truetype");
 		font-weight: 500;
 		font-style: italic;
@@ -197,11 +197,11 @@
 
 	@font-face {
 		font-family: "GuardianTextSans";
-		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Bold.woff2")
+		src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Bold.woff2")
 				format("woff2"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Bold.woff")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Bold.woff")
 				format("woff"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Bold.ttf")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Bold.ttf")
 				format("truetype");
 		font-weight: 700;
 		font-style: normal;
@@ -209,11 +209,11 @@
 
 	@font-face {
 		font-family: "GuardianTextSans";
-		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2")
+		src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BoldItalic.woff2")
 				format("woff2"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-BoldItalic.woff")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BoldItalic.woff")
 				format("woff"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-BoldItalic.ttf")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BoldItalic.ttf")
 				format("truetype");
 		font-weight: 700;
 		font-style: italic;
@@ -221,11 +221,11 @@
 
 	@font-face {
 		font-family: "GuardianTextSans";
-		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Black.woff2")
+		src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Black.woff2")
 				format("woff2"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Black.woff")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Black.woff")
 				format("woff"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-Black.ttf")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Black.ttf")
 				format("truetype");
 		font-weight: 900;
 		font-style: normal;
@@ -233,11 +233,11 @@
 
 	@font-face {
 		font-family: "GuardianTextSans";
-		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-BlackItalic.woff2")
+		src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BlackItalic.woff2")
 				format("woff2"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-BlackItalic.woff")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BlackItalic.woff")
 				format("woff"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextSans-BlackItalic.ttf")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BlackItalic.ttf")
 				format("truetype");
 		font-weight: 900;
 		font-style: italic;
@@ -247,11 +247,11 @@
 
 	@font-face {
 		font-family: "GuardianTextEgyptian";
-		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2")
+		src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Regular.woff2")
 				format("woff2"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Regular.woff")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Regular.woff")
 				format("woff"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Regular.ttf")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Regular.ttf")
 				format("truetype");
 		font-weight: 400;
 		font-style: normal;
@@ -259,11 +259,11 @@
 
 	@font-face {
 		font-family: "GuardianTextEgyptian";
-		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2")
+		src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-RegularItalic.woff2")
 				format("woff2"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-RegularItalic.woff")
 				format("woff"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.ttf")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-RegularItalic.ttf")
 				format("truetype");
 		font-weight: 400;
 		font-style: italic;
@@ -271,11 +271,11 @@
 
 	@font-face {
 		font-family: "GuardianTextEgyptian";
-		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Medium.woff2")
+		src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Medium.woff2")
 				format("woff2"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Medium.woff")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Medium.woff")
 				format("woff"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Medium.ttf")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Medium.ttf")
 				format("truetype");
 		font-weight: 500;
 		font-style: normal;
@@ -283,11 +283,11 @@
 
 	@font-face {
 		font-family: "GuardianTextEgyptian";
-		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.woff2")
+		src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-MediumItalic.woff2")
 				format("woff2"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.woff")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-MediumItalic.woff")
 				format("woff"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.ttf")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-MediumItalic.ttf")
 				format("truetype");
 		font-weight: 500;
 		font-style: italic;
@@ -295,11 +295,11 @@
 
 	@font-face {
 		font-family: "GuardianTextEgyptian";
-		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2")
+		src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Bold.woff2")
 				format("woff2"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Bold.woff")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Bold.woff")
 				format("woff"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Bold.ttf")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Bold.ttf")
 				format("truetype");
 		font-weight: 700;
 		font-style: normal;
@@ -307,11 +307,11 @@
 
 	@font-face {
 		font-family: "GuardianTextEgyptian";
-		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2")
+		src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BoldItalic.woff2")
 				format("woff2"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BoldItalic.woff")
 				format("woff"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.ttf")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BoldItalic.ttf")
 				format("truetype");
 		font-weight: 700;
 		font-style: italic;
@@ -319,11 +319,11 @@
 
 	@font-face {
 		font-family: "GuardianTextEgyptian";
-		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Black.woff2")
+		src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Black.woff2")
 				format("woff2"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Black.woff")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Black.woff")
 				format("woff"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-Black.ttf")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Black.ttf")
 				format("truetype");
 		font-weight: 900;
 		font-style: normal;
@@ -331,11 +331,11 @@
 
 	@font-face {
 		font-family: "GuardianTextEgyptian";
-		src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.woff2")
+		src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BlackItalic.woff2")
 				format("woff2"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.woff")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BlackItalic.woff")
 				format("woff"),
-			url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.ttf")
+			url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BlackItalic.ttf")
 				format("truetype");
 		font-weight: 900;
 		font-style: italic;


### PR DESCRIPTION
## What is the purpose of this change?

Guardian's fonts are not currently represented in the design system docs

## What does this change?

Adds the fonts currently hosted on interactive.guim.co.uk and pasteup.guim.co.uk

## Design

### Screenshots

**Before**

![Screenshot 2019-10-25 at 14 54 57](https://user-images.githubusercontent.com/5931528/67576949-77ff6900-f737-11e9-9de4-4c584f632ea6.png)

**After**

![Screenshot 2019-10-25 at 14 54 42](https://user-images.githubusercontent.com/5931528/67576963-7d5cb380-f737-11e9-8de3-1fb5657b1893.png)
