### PR TITLE
Improve styling of default text inputs

### DIFF
--- a/packages/text-input/index.tsx
+++ b/packages/text-input/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { textInput, text, light, dark } from "./styles"
+import { textInput, textInputWide, text, light, dark } from "./styles"
 
 type Appearance = "light" | "dark"
 
@@ -20,8 +20,8 @@ const TextInput = ({
 }) => {
 	return (
 		<label css={appearanceStyles[appearance]}>
-			<span css={text}>{labelText}</span>
-			<input css={textInput} type="text" {...props} />
+			<div css={text}>{labelText}</div>
+			<input css={[textInput, textInputWide]} type="text" {...props} />
 		</label>
 	)
 }

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -30,6 +30,7 @@
 	"dependencies": {
 		"@guardian/src-foundations": "^0.0.5",
 		"@guardian/src-helpers": "^0.0.1",
-		"@guardian/src-svgs": "^0.0.2"
+		"@guardian/src-svgs": "^0.0.2",
+		"@guardian/src-utilities": "^0.1.2"
 	}
 }

--- a/packages/text-input/stories.tsx
+++ b/packages/text-input/stories.tsx
@@ -15,7 +15,7 @@ export const defaultLight = () => (
 		storyName="default"
 		selectedValue="light"
 	>
-		<TextInput label="label" />
+		<TextInput label="First name" />
 	</WithBackgroundToggle>
 )
 defaultLight.story = {
@@ -28,7 +28,7 @@ export const defaultDark = () => (
 		storyName="default"
 		selectedValue="dark"
 	>
-		<TextInput label="label" appearance="dark" />
+		<TextInput label="First name" appearance="dark" />
 	</WithBackgroundToggle>
 )
 defaultDark.story = {

--- a/packages/text-input/styles.ts
+++ b/packages/text-input/styles.ts
@@ -1,10 +1,18 @@
 import { css } from "@emotion/core"
-import { textSans, palette, focusHalo } from "@guardian/src-foundations"
+import { textSans, palette, size } from "@guardian/src-foundations"
+import { focusHalo } from "@guardian/src-utilities"
 
 export const textInput = css`
+	height: ${size.large}px;
+	${textSans({ level: 3 })};
+
 	&:focus {
 		${focusHalo};
 	}
+`
+
+export const textInputWide = css`
+	width: 460px;
 `
 
 export const text = css`
@@ -14,17 +22,11 @@ export const text = css`
 
 export const light = css`
 	input {
-		color: ${palette.neutral[60]};
+		color: ${palette.neutral[7]};
 	}
 
 	span {
 		color: ${palette.neutral[20]};
-	}
-
-	&:hover {
-		input {
-			border-color: ${palette.brand.main};
-		}
 	}
 `
 export const dark = css`
@@ -34,11 +36,5 @@ export const dark = css`
 
 	span {
 		color: ${palette.neutral[100]};
-	}
-
-	&:hover {
-		input {
-			border-color: ${palette.neutral[100]};
-		}
 	}
 `


### PR DESCRIPTION
## What is the purpose of this change?

Styling of text input fields was very basic. Now it's starting to look like the design!

## What does this change?

Adds some very very very basic styling instructions

## Design

### Screenshots

![Screenshot 2019-10-25 at 15 39 02](https://user-images.githubusercontent.com/5931528/67580139-b730b880-f73d-11e9-95a2-396de8961a94.png)

### Accessibility

🚫  [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
