### PR TITLE
Text input theming

### DIFF
--- a/packages/text-input/index.tsx
+++ b/packages/text-input/index.tsx
@@ -11,7 +11,6 @@ const TextInput = ({ label: labelText, ...props }: { label: string }) => {
 					textInput(theme.textInput && theme),
 					textInputWide,
 				]}
-				type="text"
 				{...props}
 			/>
 		</label>
@@ -20,6 +19,7 @@ const TextInput = ({ label: labelText, ...props }: { label: string }) => {
 
 const defaultProps = {
 	disabled: false,
+	type: "text",
 }
 
 TextInput.defaultProps = { ...defaultProps }

--- a/packages/text-input/index.tsx
+++ b/packages/text-input/index.tsx
@@ -1,33 +1,24 @@
 import React from "react"
-import { textInput, textInputWide, text, light, dark } from "./styles"
+import { textInput, textInputWide, text } from "./styles"
+export * from "./themes"
 
-type Appearance = "light" | "dark"
-
-const appearanceStyles: {
-	[key in Appearance]: any
-} = {
-	light: light,
-	dark: dark,
-}
-
-const TextInput = ({
-	label: labelText,
-	appearance,
-	...props
-}: {
-	label: string
-	appearance: Appearance
-}) => {
+const TextInput = ({ label: labelText, ...props }: { label: string }) => {
 	return (
-		<label css={appearanceStyles[appearance]}>
-			<div css={text}>{labelText}</div>
-			<input css={[textInput, textInputWide]} type="text" {...props} />
+		<label>
+			<div css={theme => text(theme.textInput && theme)}>{labelText}</div>
+			<input
+				css={theme => [
+					textInput(theme.textInput && theme),
+					textInputWide,
+				]}
+				type="text"
+				{...props}
+			/>
 		</label>
 	)
 }
 
 const defaultProps = {
-	appearance: "light",
 	disabled: false,
 }
 

--- a/packages/text-input/stories.tsx
+++ b/packages/text-input/stories.tsx
@@ -1,9 +1,10 @@
 import React from "react"
+import { ThemeProvider } from "emotion-theming"
 import {
 	storybookBackgrounds,
 	WithBackgroundToggle,
 } from "@guardian/src-helpers"
-import { TextInput } from "./index"
+import { TextInput, lightTheme, darkTheme } from "./index"
 
 export default {
 	title: "TextInput",
@@ -15,7 +16,9 @@ export const defaultLight = () => (
 		storyName="default"
 		selectedValue="light"
 	>
-		<TextInput label="First name" />
+		<ThemeProvider theme={lightTheme}>
+			<TextInput label="First name" />
+		</ThemeProvider>
 	</WithBackgroundToggle>
 )
 defaultLight.story = {
@@ -28,7 +31,9 @@ export const defaultDark = () => (
 		storyName="default"
 		selectedValue="dark"
 	>
-		<TextInput label="First name" appearance="dark" />
+		<ThemeProvider theme={darkTheme}>
+			<TextInput label="First name" />
+		</ThemeProvider>
 	</WithBackgroundToggle>
 )
 defaultDark.story = {

--- a/packages/text-input/styles.ts
+++ b/packages/text-input/styles.ts
@@ -1,10 +1,14 @@
 import { css } from "@emotion/core"
-import { textSans, palette, size } from "@guardian/src-foundations"
+import { textSans, size } from "@guardian/src-foundations"
 import { focusHalo } from "@guardian/src-utilities"
+import { lightTheme, TextInputTheme } from "./themes"
 
-export const textInput = css`
+export const textInput = ({
+	textInput,
+}: { textInput: TextInputTheme } = lightTheme) => css`
 	height: ${size.large}px;
 	${textSans({ level: 3 })};
+	color: ${textInput.inputColor};
 
 	&:focus {
 		${focusHalo};
@@ -15,26 +19,10 @@ export const textInputWide = css`
 	width: 460px;
 `
 
-export const text = css`
+export const text = ({
+	textInput,
+}: { textInput: TextInputTheme } = lightTheme) => css`
 	position: relative;
 	${textSans({ level: 3 })};
-`
-
-export const light = css`
-	input {
-		color: ${palette.neutral[7]};
-	}
-
-	span {
-		color: ${palette.neutral[20]};
-	}
-`
-export const dark = css`
-	input {
-		color: ${palette.brand.pastel};
-	}
-
-	span {
-		color: ${palette.neutral[100]};
-	}
+	color: ${textInput.textColor};
 `

--- a/packages/text-input/themes.ts
+++ b/packages/text-input/themes.ts
@@ -1,0 +1,20 @@
+import { palette } from "@guardian/src-foundations"
+
+export type TextInputTheme = {
+	inputColor: string
+	textColor: string
+}
+
+export const lightTheme: { textInput: TextInputTheme } = {
+	textInput: {
+		inputColor: palette.neutral[7],
+		textColor: palette.neutral[20],
+	},
+}
+
+export const darkTheme: { textInput: TextInputTheme } = {
+	textInput: {
+		inputColor: palette.brand.pastel,
+		textColor: palette.neutral[100],
+	},
+}


### PR DESCRIPTION
## What is the purpose of this change?

TextInput components have an older version of theming using the "appearance" prop. We need to migrate this to the new theming  approach using emotion-theming

## What does this change?

Removes the legacy "appearance" prop form `TextInput` components and instead supporting Theming via emotion-theming
