### PR TITLE
Support InlineError in TextInput

### DIFF
--- a/packages/radio/index.tsx
+++ b/packages/radio/index.tsx
@@ -83,11 +83,13 @@ const SupportingText = ({ children }: { children: ReactNode }) => {
 
 const Radio = ({
 	label: labelContent,
+	value,
 	supporting,
 	error,
 	...props
 }: {
 	label: string
+	value: string
 	supporting?: string
 	error?: boolean
 }) => {
@@ -103,6 +105,7 @@ const Radio = ({
 					radio(theme.radio && theme),
 					error ? errorRadio : "",
 				]}
+				value={value}
 				aria-invalid={error}
 				{...props}
 			/>
@@ -126,6 +129,7 @@ const radioGroupDefaultProps = {
 const radioDefaultProps = {
 	disabled: false,
 	type: "radio",
+	defaultChecked: false,
 }
 
 Radio.defaultProps = { ...radioDefaultProps }

--- a/packages/text-input/index.tsx
+++ b/packages/text-input/index.tsx
@@ -1,15 +1,25 @@
 import React from "react"
-import { textInput, textInputWide, text } from "./styles"
+import { InlineError } from "@guardian/src-inline-error"
+import { textInput, textInputWide, text, errorInput } from "./styles"
 export * from "./themes"
 
-const TextInput = ({ label: labelText, ...props }: { label: string }) => {
+const TextInput = ({
+	label: labelText,
+	error,
+	...props
+}: {
+	label: string
+	error?: boolean | string
+}) => {
 	return (
 		<label>
 			<div css={theme => text(theme.textInput && theme)}>{labelText}</div>
+			{typeof error === "string" && <InlineError>{error}</InlineError>}
 			<input
 				css={theme => [
 					textInput(theme.textInput && theme),
 					textInputWide,
+					error ? errorInput : "",
 				]}
 				{...props}
 			/>

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -30,6 +30,7 @@
 	"dependencies": {
 		"@guardian/src-foundations": "^0.0.5",
 		"@guardian/src-helpers": "^0.0.1",
+		"@guardian/src-inline-error": "^0.0.3",
 		"@guardian/src-svgs": "^0.0.2",
 		"@guardian/src-utilities": "^0.1.2"
 	}

--- a/packages/text-input/stories.tsx
+++ b/packages/text-input/stories.tsx
@@ -3,44 +3,147 @@ import { ThemeProvider } from "emotion-theming"
 import {
 	storybookBackgrounds,
 	WithBackgroundToggle,
+	Appearance,
 } from "@guardian/src-helpers"
-import { TextInput, lightTheme, darkTheme } from "./index"
+import { TextInput, TextInputTheme, lightTheme, darkTheme } from "./index"
 
 export default {
 	title: "TextInput",
 }
 
-export const defaultLight = () => (
-	<WithBackgroundToggle
-		storyKind="TextInput"
-		storyName="default"
-		selectedValue="light"
-	>
-		<ThemeProvider theme={lightTheme}>
-			<TextInput label="First name" />
-		</ThemeProvider>
-	</WithBackgroundToggle>
-)
-defaultLight.story = {
-	name: "default light",
-}
-
-export const defaultDark = () => (
-	<WithBackgroundToggle
-		storyKind="TextInput"
-		storyName="default"
-		selectedValue="dark"
-	>
-		<ThemeProvider theme={darkTheme}>
-			<TextInput label="First name" />
-		</ThemeProvider>
-	</WithBackgroundToggle>
-)
-defaultDark.story = {
-	name: "default dark",
-	parameters: {
-		backgrounds: [
-			Object.assign({}, { default: true }, storybookBackgrounds.dark),
-		],
+const appearances: {
+	name: Appearance
+	theme: { textInput: TextInputTheme }
+}[] = [
+	{
+		name: "light",
+		theme: lightTheme,
 	},
+	{
+		name: "dark",
+		theme: darkTheme,
+	},
+]
+
+const [defaultLight, defaultDark] = appearances.map(
+	({
+		name,
+		theme,
+	}: {
+		name: Appearance
+		theme: { textInput: TextInputTheme }
+	}) => {
+		const story = () => (
+			<WithBackgroundToggle
+				storyKind="TextInput"
+				storyName="default"
+				selectedValue={name}
+			>
+				<ThemeProvider theme={theme}>
+					<TextInput label="First name" />
+				</ThemeProvider>
+			</WithBackgroundToggle>
+		)
+
+		story.story = {
+			name: `default ${name}`,
+			parameters: {
+				backgrounds: [
+					Object.assign(
+						{},
+						{ default: true },
+						storybookBackgrounds[name],
+					),
+				],
+			},
+		}
+
+		return story
+	},
+)
+
+const [errorWithMessageLight, errorWithMessageDark] = appearances.map(
+	({
+		name,
+		theme,
+	}: {
+		name: Appearance
+		theme: { textInput: TextInputTheme }
+	}) => {
+		const story = () => (
+			<WithBackgroundToggle
+				storyKind="TextInput"
+				storyName="error with message"
+				selectedValue={name}
+			>
+				<ThemeProvider theme={theme}>
+					<TextInput
+						label="First name"
+						error="Enter your first name below"
+					/>
+				</ThemeProvider>
+			</WithBackgroundToggle>
+		)
+
+		story.story = {
+			name: `error with message ${name}`,
+			parameters: {
+				backgrounds: [
+					Object.assign(
+						{},
+						{ default: true },
+						storybookBackgrounds[name],
+					),
+				],
+			},
+		}
+
+		return story
+	},
+)
+
+const [errorWithoutMessageLight, errorWithoutMessageDark] = appearances.map(
+	({
+		name,
+		theme,
+	}: {
+		name: Appearance
+		theme: { textInput: TextInputTheme }
+	}) => {
+		const story = () => (
+			<WithBackgroundToggle
+				storyKind="TextInput"
+				storyName="error without message"
+				selectedValue={name}
+			>
+				<ThemeProvider theme={theme}>
+					<TextInput label="First name" error={true} />
+				</ThemeProvider>
+			</WithBackgroundToggle>
+		)
+
+		story.story = {
+			name: `error without message ${name}`,
+			parameters: {
+				backgrounds: [
+					Object.assign(
+						{},
+						{ default: true },
+						storybookBackgrounds[name],
+					),
+				],
+			},
+		}
+
+		return story
+	},
+)
+
+export {
+	defaultLight,
+	defaultDark,
+	errorWithMessageLight,
+	errorWithMessageDark,
+	errorWithoutMessageLight,
+	errorWithoutMessageDark,
 }

--- a/packages/text-input/styles.ts
+++ b/packages/text-input/styles.ts
@@ -1,5 +1,5 @@
 import { css } from "@emotion/core"
-import { textSans, size } from "@guardian/src-foundations"
+import { textSans, size, palette } from "@guardian/src-foundations"
 import { focusHalo } from "@guardian/src-utilities"
 import { lightTheme, TextInputTheme } from "./themes"
 
@@ -25,4 +25,8 @@ export const text = ({
 	position: relative;
 	${textSans({ level: 3 })};
 	color: ${textInput.textColor};
+`
+
+export const errorInput = css`
+	border: 4px solid ${palette.error.main};
 `


### PR DESCRIPTION
## What is the purpose of this change?

It is necessary to support error messages in Text Inputs, letting the user know if the field has been completed incorrectly.

## What does this change?

Adds the optional error prop to the TextInput component. 

If error is a string, the InlineError component is displayed below the field label.
If error is true, the input field error styling will be applied.

## Design

### Screenshots

**With error message:**

![Screenshot 2019-10-28 at 11 49 28](https://user-images.githubusercontent.com/5931528/67676441-67d6cc00-f979-11e9-99e4-bed1459bd8a2.png)

**Without error message:**

![Screenshot 2019-10-28 at 11 49 34](https://user-images.githubusercontent.com/5931528/67676442-67d6cc00-f979-11e9-8d2f-65380c6030a5.png)

### Accessibility

 🚫  [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
