### PR TITLE
Add supporting text prop to text input

### DIFF
--- a/packages/text-input/index.tsx
+++ b/packages/text-input/index.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { ReactNode } from "react"
 import { InlineError } from "@guardian/src-inline-error"
 import {
 	textInput,
@@ -6,18 +6,25 @@ import {
 	text,
 	errorInput,
 	optionalLabel,
+	supportingText,
 } from "./styles"
 export * from "./themes"
+
+const SupportingText = ({ children }: { children: ReactNode }) => {
+	return <div css={supportingText}>{children}</div>
+}
 
 const TextInput = ({
 	label: labelText,
 	error,
 	optional,
+	supporting,
 	...props
 }: {
 	label: string
 	error: boolean | string
 	optional: boolean
+	supporting?: string
 }) => {
 	return (
 		<label>
@@ -25,6 +32,7 @@ const TextInput = ({
 				{labelText}{" "}
 				{optional ? <span css={optionalLabel}>Optional</span> : ""}
 			</div>
+			{supporting ? <SupportingText>{supporting}</SupportingText> : ""}
 			{typeof error === "string" && <InlineError>{error}</InlineError>}
 			<input
 				css={theme => [

--- a/packages/text-input/stories.tsx
+++ b/packages/text-input/stories.tsx
@@ -179,6 +179,43 @@ const [optionalLight, optionalDark] = appearances.map(
 		return story
 	},
 )
+const [supportingTextLight, supportingTextDark] = appearances.map(
+	({
+		name,
+		theme,
+	}: {
+		name: Appearance
+		theme: { textInput: TextInputTheme }
+	}) => {
+		const story = () => (
+			<WithBackgroundToggle
+				storyKind="TextInput"
+				storyName="supporting text"
+				options={appearances.map(a => a.name)}
+				selectedValue={name}
+			>
+				<ThemeProvider theme={theme}>
+					<TextInput label="Email" supporting="alex@example.com" />
+				</ThemeProvider>
+			</WithBackgroundToggle>
+		)
+
+		story.story = {
+			name: `supporting text ${name}`,
+			parameters: {
+				backgrounds: [
+					Object.assign(
+						{},
+						{ default: true },
+						storybookBackgrounds[name],
+					),
+				],
+			},
+		}
+
+		return story
+	},
+)
 
 export {
 	defaultLight,
@@ -189,4 +226,6 @@ export {
 	errorWithoutMessageDark,
 	optionalLight,
 	optionalDark,
+	supportingTextLight,
+	supportingTextDark,
 }

--- a/packages/text-input/styles.ts
+++ b/packages/text-input/styles.ts
@@ -38,3 +38,9 @@ export const optionalLabel = css`
 	color: ${palette.neutral[46]};
 	font-style: italic;
 `
+
+export const supportingText = css`
+	${textSans({ level: 2 })};
+	color: ${palette.neutral[46]};
+	margin-bottom: ${space.half}px;
+`


### PR DESCRIPTION
## What is the purpose of this change?

Allows developer to add supporting text below a text input label.  The aim is to further clarify the purpose of the text field, and add reassurance. 

## What does this change?

Adds a `supporting` prop to the text input component. If this is set, the supporting text is added below the label.

## Design

### Screenshots

![Screenshot 2019-10-29 at 09 16 36](https://user-images.githubusercontent.com/5931528/67753571-d32da600-fa2c-11e9-9772-d4f2896a74b3.png)

### Accessibility

🚫  [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
