### PR TITLE
Add new error colour

### DIFF
--- a/packages/foundations/package.json
+++ b/packages/foundations/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-foundations",
-	"version": "0.5.0-alpha.4",
+	"version": "0.5.0-alpha.5",
 	"main": "dist/foundations.js",
 	"module": "dist/foundations.esm.js",
 	"scripts": {

--- a/packages/foundations/palette.ts
+++ b/packages/foundations/palette.ts
@@ -26,6 +26,7 @@ const palette = {
 	},
 	error: {
 		main: colors.reds[1],
+		bright: colors.reds[2],
 	},
 	news: {
 		dark: colors.reds[0],


### PR DESCRIPTION
## What is the purpose of this change?

Error messages and component states don't show up very well against dark backgrounds. We need to expose a new contextual colour for this purpose.

## What does this change?

 Exposes `#FF5943` as `palette.error.bright`

## Design

### Screenshots

![Screenshot 2019-10-31 at 15 45 43](https://user-images.githubusercontent.com/5931528/67962783-83e6a180-fbf5-11e9-9998-b42a791d56e6.png)

### Accessibility

🚫  [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
🚫  [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
