### PR TITLE
Improve colour of inline error on blue background

### DIFF
--- a/packages/foundations/mq.ts
+++ b/packages/foundations/mq.ts
@@ -2,7 +2,7 @@ import { breakpoints } from "@guardian/src-foundations"
 
 // Duplicated from breakpoints.ts because of some issue importing directly
 // babel * typescript * rollup = ¯\_(ツ)_/¯
-export type Breakpoint =
+type Breakpoint =
 	| "mobileMedium"
 	| "mobileLandscape"
 	| "phablet"

--- a/packages/helpers/storybook-bg-toggle.tsx
+++ b/packages/helpers/storybook-bg-toggle.tsx
@@ -44,6 +44,8 @@ export const WithBackgroundToggle = ({
 		{children}
 		<select
 			value={`${storyName} ${selectedValue}`}
+			/* eslint-disable-next-line @typescript-eslint/ban-ts-ignore */
+			//@ts-ignore
 			onChange={linkTo(storyKind, (e: Event) => {
 				const target = e.currentTarget as HTMLSelectElement
 

--- a/packages/inline-error/index.tsx
+++ b/packages/inline-error/index.tsx
@@ -1,9 +1,10 @@
 import React, { ReactNode } from "react"
 import { inlineError } from "./styles"
 import { SvgAlert } from "@guardian/src-svgs"
+export * from "./themes"
 
 const InlineError = ({ children }: { children: ReactNode }) => (
-	<span css={inlineError}>
+	<span css={theme => inlineError(theme.inlineError && theme)}>
 		<SvgAlert />
 		{children}
 	</span>

--- a/packages/inline-error/package.json
+++ b/packages/inline-error/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-inline-error",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"main": "dist/inline-error.js",
 	"module": "dist/inline-error.esm.js",
 	"scripts": {
@@ -29,7 +29,7 @@
 		"react": "^16.8.6"
 	},
 	"dependencies": {
-		"@guardian/src-foundations": "^0.2.2",
+		"@guardian/src-foundations": "^0.5.0-alpha.5",
 		"@guardian/src-svgs": "^0.0.5"
 	}
 }

--- a/packages/inline-error/package.json
+++ b/packages/inline-error/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-inline-error",
-	"version": "0.0.4",
+	"version": "0.0.3",
 	"main": "dist/inline-error.js",
 	"module": "dist/inline-error.esm.js",
 	"scripts": {

--- a/packages/inline-error/stories.tsx
+++ b/packages/inline-error/stories.tsx
@@ -1,13 +1,61 @@
 import React from "react"
+import { ThemeProvider } from "emotion-theming"
+import {
+	Appearance,
+	WithBackgroundToggle,
+	storybookBackgrounds,
+} from "@guardian/src-helpers"
 import { InlineError } from "./index"
+import { InlineErrorTheme, lightTheme, blueTheme } from "./themes"
 
 export default {
 	title: "InlineError",
 }
 
-export const defaultLight = () => (
-	<InlineError>Please enter your name</InlineError>
+const appearances: {
+	name: Appearance
+	theme: { inlineError: InlineErrorTheme }
+}[] = [
+	{
+		name: "light",
+		theme: lightTheme,
+	},
+	{ name: "blue", theme: blueTheme },
+]
+
+const [defaultLight, defaultBlue] = appearances.map(
+	(appearance: {
+		name: Appearance
+		theme: { inlineError: InlineErrorTheme }
+	}) => {
+		const story = () => (
+			<WithBackgroundToggle
+				storyKind="InlineError"
+				storyName="default"
+				options={appearances.map(a => a.name)}
+				selectedValue={appearance.name}
+			>
+				<ThemeProvider theme={appearance.theme}>
+					<InlineError>Please enter your name</InlineError>
+				</ThemeProvider>
+			</WithBackgroundToggle>
+		)
+
+		story.story = {
+			name: `default ${appearance.name}`,
+			parameters: {
+				backgrounds: [
+					Object.assign(
+						{},
+						{ default: true },
+						storybookBackgrounds[appearance.name],
+					),
+				],
+			},
+		}
+
+		return story
+	},
 )
-defaultLight.story = {
-	name: "default light",
-}
+
+export { defaultLight, defaultBlue }

--- a/packages/inline-error/styles.ts
+++ b/packages/inline-error/styles.ts
@@ -1,11 +1,14 @@
 import { css } from "@emotion/core"
-import { textSans, palette, space } from "@guardian/src-foundations"
+import { textSans, space } from "@guardian/src-foundations"
+import { lightTheme, InlineErrorTheme } from "./themes"
 
-export const inlineError = css`
+export const inlineError = ({
+	inlineError,
+}: { inlineError: InlineErrorTheme } = lightTheme) => css`
 	display: flex;
 	align-items: center;
 	${textSans({ level: 3 })};
-	color: ${palette.error.main};
+	color: ${inlineError.color};
 	margin-bottom: ${space[1]}px;
 
 	svg {

--- a/packages/inline-error/themes.ts
+++ b/packages/inline-error/themes.ts
@@ -1,0 +1,17 @@
+import { palette } from "@guardian/src-foundations"
+
+export type InlineErrorTheme = {
+	color: string
+}
+
+export const lightTheme: { inlineError: InlineErrorTheme } = {
+	inlineError: {
+		color: palette.error.main,
+	},
+}
+
+export const blueTheme: { inlineError: InlineErrorTheme } = {
+	inlineError: {
+		color: palette.error.bright,
+	},
+}

--- a/packages/radio/styles.ts
+++ b/packages/radio/styles.ts
@@ -1,11 +1,5 @@
 import { css } from "@emotion/core"
-import {
-	textSans,
-	palette,
-	space,
-	size,
-	transitions,
-} from "@guardian/src-foundations"
+import { textSans, space, size, transitions } from "@guardian/src-foundations"
 import { focusHalo } from "@guardian/src-utilities"
 import { RadioTheme, lightTheme } from "./themes"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1109,11 +1109,6 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.0.5.tgz#c69fd44123503b00a838fb18b0c37f2d6aac771c"
   integrity sha512-gmSoGe3LPkoqk9Ro8okPXyEcT4ClM4JjC6yMaIMH3vgdSxQzs8Gh+mhgX3LnX9lYflrnuWeaiub1vN8hOqUaYQ==
 
-"@guardian/src-foundations@^0.2.2":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.2.4.tgz#a2dc8267be6efb19c684b1bb27099ad58d887c3b"
-  integrity sha512-SYijZJndBv6bvoFHaWgAo2iOSkZgi4pLQWKB2GYOf5wzN1R/DOl3UUjNUHSF7vKVDzNnsChfiopl4WSx2gIH8g==
-
 "@guardian/src-foundations@^0.3.1":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.3.2.tgz#8b7b7bfc25fcdaddc10c6f540167e6633c86e948"


### PR DESCRIPTION
## What is the purpose of this change?

To build on #71, inline error messages need an accessible colour on the brand blue background

## What does this change?

- Introduces theme approach for inline error
- Uses `palette.error.bright` for text and SVG colour on blue theme
- Fixes (and hides) a few type errors

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

![Screenshot 2019-11-01 at 09 20 55](https://user-images.githubusercontent.com/5931528/68014989-eccb2980-fc88-11e9-9528-1a64278efe2b.png)


### Accessibility

🚫  [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
🚫  [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
