### PR TITLE
Update inline error

### DIFF
--- a/packages/inline-error/package.json
+++ b/packages/inline-error/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-inline-error",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"main": "dist/inline-error.js",
 	"module": "dist/inline-error.esm.js",
 	"scripts": {

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -31,7 +31,7 @@
 	},
 	"dependencies": {
 		"@guardian/src-foundations": "^0.0.5",
-		"@guardian/src-inline-error": "^0.0.3",
+		"@guardian/src-inline-error": "^0.0.4",
 		"@guardian/src-svgs": "^0.0.2",
 		"@guardian/src-utilities": "^0.1.2"
 	}

--- a/packages/radio/stories.tsx
+++ b/packages/radio/stories.tsx
@@ -3,7 +3,7 @@ import {
 	storybookBackgrounds,
 	WithBackgroundToggle,
 } from "@guardian/src-helpers"
-import { RadioGroup, Radio, RadioTheme, lightTheme, blueTheme } from "./index"
+import { RadioGroup, Radio, lightTheme, blueTheme } from "./index"
 import { Appearance } from "@guardian/src-helpers"
 import { ThemeProvider } from "emotion-theming"
 
@@ -44,7 +44,7 @@ export default {
 
 const appearances: {
 	name: Appearance
-	theme: { radio: RadioTheme }
+	theme: {}
 }[] = [
 	{
 		name: "light",
@@ -54,7 +54,7 @@ const appearances: {
 ]
 
 const [verticalLight, verticalBlue] = appearances.map(
-	(appearance: { name: Appearance; theme: { radio: RadioTheme } }) => {
+	(appearance: { name: Appearance; theme: {} }) => {
 		const story = () => (
 			<WithBackgroundToggle
 				storyKind="Radio"
@@ -89,7 +89,7 @@ const [verticalLight, verticalBlue] = appearances.map(
 )
 
 const [supportingTextLight, supportingTextBlue] = appearances.map(
-	(appearance: { name: Appearance; theme: { radio: RadioTheme } }) => {
+	(appearance: { name: Appearance; theme: {} }) => {
 		const story = () => (
 			<WithBackgroundToggle
 				storyKind="Radio"
@@ -134,7 +134,7 @@ horizontal.story = {
 }
 
 const [errorWithMessageLight, errorWithMessageBlue] = appearances.map(
-	(appearance: { name: Appearance; theme: { radio: RadioTheme } }) => {
+	(appearance: { name: Appearance; theme: {} }) => {
 		const story = () => (
 			<WithBackgroundToggle
 				storyKind="Radio"

--- a/packages/radio/themes.ts
+++ b/packages/radio/themes.ts
@@ -1,4 +1,9 @@
 import { palette } from "@guardian/src-foundations"
+import {
+	lightTheme as inlineErrorLightTheme,
+	blueTheme as inlineErrorBlueTheme,
+	InlineErrorTheme,
+} from "@guardian/src-inline-error"
 
 export type RadioTheme = {
 	hoverBorderColor: string
@@ -9,7 +14,10 @@ export type RadioTheme = {
 	errorColor: string
 }
 
-export const lightTheme: { radio: RadioTheme } = {
+export const lightTheme: {
+	radio: RadioTheme
+	inlineError: InlineErrorTheme
+} = {
 	radio: {
 		hoverBorderColor: palette.brand.main,
 		color: palette.neutral[60],
@@ -18,9 +26,10 @@ export const lightTheme: { radio: RadioTheme } = {
 		supportingTextColor: palette.neutral[46],
 		errorColor: palette.error.main,
 	},
+	...inlineErrorLightTheme,
 }
 
-export const blueTheme: { radio: RadioTheme } = {
+export const blueTheme: { radio: RadioTheme; inlineError: InlineErrorTheme } = {
 	radio: {
 		hoverBorderColor: palette.neutral[100],
 		color: palette.brand.faded,
@@ -29,4 +38,5 @@ export const blueTheme: { radio: RadioTheme } = {
 		supportingTextColor: palette.brand.faded,
 		errorColor: palette.error.bright,
 	},
+	...inlineErrorBlueTheme,
 }

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@guardian/src-foundations": "^0.5.0-alpha.1",
 		"@guardian/src-helpers": "^0.0.1",
-		"@guardian/src-inline-error": "^0.0.3",
+		"@guardian/src-inline-error": "^0.0.4",
 		"@guardian/src-svgs": "^0.0.2",
 		"@guardian/src-utilities": "^0.1.2"
 	}

--- a/packages/text-input/stories.tsx
+++ b/packages/text-input/stories.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { css } from "@emotion/core"
 import { ThemeProvider } from "emotion-theming"
 import { storybookBackgrounds, Appearance } from "@guardian/src-helpers"
-import { TextInput, TextInputTheme, lightTheme } from "./index"
+import { TextInput, lightTheme } from "./index"
 
 export default {
 	title: "TextInput",
@@ -10,7 +10,7 @@ export default {
 
 const appearances: {
 	name: Appearance
-	theme: { textInput: TextInputTheme }
+	theme: {}
 }[] = [
 	{
 		name: "light",
@@ -23,13 +23,7 @@ const constrainedWith = css`
 `
 
 const [defaultLight] = appearances.map(
-	({
-		name,
-		theme,
-	}: {
-		name: Appearance
-		theme: { textInput: TextInputTheme }
-	}) => {
+	({ name, theme }: { name: Appearance; theme: {} }) => {
 		const story = () => (
 			<ThemeProvider theme={theme}>
 				<div css={constrainedWith}>
@@ -56,13 +50,7 @@ const [defaultLight] = appearances.map(
 )
 
 const [optionalLight] = appearances.map(
-	({
-		name,
-		theme,
-	}: {
-		name: Appearance
-		theme: { textInput: TextInputTheme }
-	}) => {
+	({ name, theme }: { name: Appearance; theme: {} }) => {
 		const story = () => (
 			<ThemeProvider theme={theme}>
 				<div css={constrainedWith}>
@@ -88,13 +76,7 @@ const [optionalLight] = appearances.map(
 	},
 )
 const [supportingTextLight] = appearances.map(
-	({
-		name,
-		theme,
-	}: {
-		name: Appearance
-		theme: { textInput: TextInputTheme }
-	}) => {
+	({ name, theme }: { name: Appearance; theme: {} }) => {
 		const story = () => (
 			<ThemeProvider theme={theme}>
 				<div css={constrainedWith}>
@@ -121,13 +103,7 @@ const [supportingTextLight] = appearances.map(
 )
 
 const [widthsLight] = appearances.map(
-	({
-		name,
-		theme,
-	}: {
-		name: Appearance
-		theme: { textInput: TextInputTheme }
-	}) => {
+	({ name, theme }: { name: Appearance; theme: {} }) => {
 		const story = () => (
 			<ThemeProvider theme={theme}>
 				<div>
@@ -160,13 +136,7 @@ const [widthsLight] = appearances.map(
 )
 
 const [errorWithMessageLight] = appearances.map(
-	({
-		name,
-		theme,
-	}: {
-		name: Appearance
-		theme: { textInput: TextInputTheme }
-	}) => {
+	({ name, theme }: { name: Appearance; theme: {} }) => {
 		const story = () => (
 			<ThemeProvider theme={theme}>
 				<div css={constrainedWith}>
@@ -196,13 +166,7 @@ const [errorWithMessageLight] = appearances.map(
 )
 
 const [errorWithoutMessageLight] = appearances.map(
-	({
-		name,
-		theme,
-	}: {
-		name: Appearance
-		theme: { textInput: TextInputTheme }
-	}) => {
+	({ name, theme }: { name: Appearance; theme: {} }) => {
 		const story = () => (
 			<ThemeProvider theme={theme}>
 				<div css={constrainedWith}>

--- a/packages/text-input/themes.ts
+++ b/packages/text-input/themes.ts
@@ -1,4 +1,8 @@
 import { palette } from "@guardian/src-foundations"
+import {
+	lightTheme as inlineErrorLightTheme,
+	InlineErrorTheme,
+} from "@guardian/src-inline-error"
 
 export type TextInputTheme = {
 	inputColor: string
@@ -6,10 +10,14 @@ export type TextInputTheme = {
 	backgroundColor: string
 }
 
-export const lightTheme: { textInput: TextInputTheme } = {
+export const lightTheme: {
+	textInput: TextInputTheme
+	inlineError: InlineErrorTheme
+} = {
 	textInput: {
 		inputColor: palette.neutral[7],
 		textColor: palette.neutral[20],
 		backgroundColor: palette.neutral[100],
 	},
+	...inlineErrorLightTheme,
 }


### PR DESCRIPTION
## What is the purpose of this change?

Following #73, ensure this change is propagated to components that use the inline error

## What does this change?

- bumps versions of inline error and components that use it
- since inline error is now themed, the components that use it mix the inline error's theme into their own themes

## Todo

Theming is a bit clunky right now. The user needs to know which components their application uses and manually mix them all together at the top level. Perhaps we can improve this.

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

![Screenshot 2019-11-01 at 10 42 09](https://user-images.githubusercontent.com/5931528/68019655-4f75f280-fc94-11e9-9609-14899e81372d.png)


### Accessibility

🚫  [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
🚫  [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
