### PR TITLE
Make src-foundations a peer dependency of every component

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		"build:button": "cd packages/button && yarn build",
 		"build:inline-error": "cd packages/inline-error && yarn build",
 		"build:radio": "cd packages/radio && yarn build",
-		"build": "NODE_ENV=production yarn build:storybook && yarn build:foundations && yarn build:utilities && yarn build:svgs && yarn build:button && yarn build:inline-error && yarn build:radio"
+		"build:text-input": "cd packages/text-input && yarn build",
+		"build": "NODE_ENV=production yarn build:storybook && yarn build:foundations && yarn build:utilities && yarn build:svgs && yarn build:button && yarn build:inline-error && yarn build:radio && yarn build:text-input"
 	},
 	"private": true,
 	"workspaces": [

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 ```sh
-$ yarn add @guardian/src-button
+$ yarn add @guardian/src-button @guardian/src-foundations
 ```
 
 ## Use

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-button",
-	"version": "0.1.1",
+	"version": "0.2.1",
 	"main": "dist/button.js",
 	"module": "dist/button.esm.js",
 	"scripts": {

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -4,7 +4,7 @@
 	"main": "dist/button.js",
 	"module": "dist/button.esm.js",
 	"scripts": {
-		"build": "rollup --config",
+		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
 		"prepublish": "yarn build"
 	},
@@ -14,6 +14,9 @@
 		"@babel/preset-react": "^7.0.0",
 		"@babel/preset-typescript": "^7.3.3",
 		"@emotion/babel-preset-css-prop": "^10.0.14",
+		"@guardian/src-foundations": "^0.5.0",
+		"@guardian/src-helpers": "^0.0.1",
+		"@guardian/src-svgs": "^0.0.2",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
 		"rollup-plugin-commonjs": "^10.0.2",
@@ -26,11 +29,7 @@
 	],
 	"peerDependencies": {
 		"@emotion/core": "^10.0.14",
-		"react": "^16.8.6"
-	},
-	"dependencies": {
 		"@guardian/src-foundations": "^0.5.0",
-		"@guardian/src-helpers": "^0.0.1",
-		"@guardian/src-svgs": "^0.0.2"
+		"react": "^16.8.6"
 	}
 }

--- a/packages/button/rollup.config.js
+++ b/packages/button/rollup.config.js
@@ -16,6 +16,12 @@ module.exports = {
 			format: "esm",
 		},
 	],
-	external: ["react", "@emotion/core", "@emotion/css"],
+	external: [
+		"react",
+		"@emotion/core",
+		"@emotion/css",
+		"@guardian/src-foundations",
+		"@guardian/src-foundations/accessibility",
+	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/packages/inline-error/package.json
+++ b/packages/inline-error/package.json
@@ -4,7 +4,7 @@
 	"main": "dist/inline-error.js",
 	"module": "dist/inline-error.esm.js",
 	"scripts": {
-		"build": "rollup --config",
+		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
 		"prepublish": "yarn build"
 	},
@@ -14,6 +14,7 @@
 		"@babel/preset-react": "^7.0.0",
 		"@babel/preset-typescript": "^7.3.3",
 		"@emotion/babel-preset-css-prop": "^10.0.14",
+		"@guardian/src-foundations": "^0.5.0",
 		"@guardian/src-helpers": "^0.0.1",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
@@ -26,10 +27,10 @@
 	],
 	"peerDependencies": {
 		"@emotion/core": "^10.0.14",
+		"@guardian/src-foundations": "^0.5.0",
 		"react": "^16.8.6"
 	},
 	"dependencies": {
-		"@guardian/src-foundations": "^0.5.0",
 		"@guardian/src-svgs": "^0.0.5"
 	}
 }

--- a/packages/inline-error/package.json
+++ b/packages/inline-error/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-inline-error",
-	"version": "0.0.4",
+	"version": "0.1.0",
 	"main": "dist/inline-error.js",
 	"module": "dist/inline-error.esm.js",
 	"scripts": {

--- a/packages/inline-error/rollup.config.js
+++ b/packages/inline-error/rollup.config.js
@@ -18,6 +18,11 @@ module.exports = {
 			sourceMap: true,
 		},
 	],
-	external: ["react", "@emotion/core", "@emotion/css"],
+	external: [
+		"react",
+		"@emotion/core",
+		"@emotion/css",
+		"@guardian/src-foundations",
+	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 ```sh
-$ yarn add @guardian/src-radio
+$ yarn add @guardian/src-radio @guardian/src-foundations
 ```
 
 ## Use

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -4,7 +4,7 @@
 	"main": "dist/radio.js",
 	"module": "dist/radio.esm.js",
 	"scripts": {
-		"build": "rollup --config",
+		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
 		"prepublish": "yarn build"
 	},
@@ -14,6 +14,7 @@
 		"@babel/preset-react": "^7.0.0",
 		"@babel/preset-typescript": "^7.3.3",
 		"@emotion/babel-preset-css-prop": "^10.0.14",
+		"@guardian/src-foundations": "^0.5.0",
 		"@guardian/src-helpers": "^0.0.1",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
@@ -27,10 +28,10 @@
 	],
 	"peerDependencies": {
 		"@emotion/core": "^10.0.14",
+		"@guardian/src-foundations": "^0.5.0",
 		"react": "^16.8.6"
 	},
 	"dependencies": {
-		"@guardian/src-foundations": "^0.5.0",
 		"@guardian/src-inline-error": "^0.0.4",
 		"@guardian/src-svgs": "^0.0.2"
 	}

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-radio",
-	"version": "0.0.6",
+	"version": "0.1.0",
 	"main": "dist/radio.js",
 	"module": "dist/radio.esm.js",
 	"scripts": {

--- a/packages/radio/rollup.config.js
+++ b/packages/radio/rollup.config.js
@@ -16,6 +16,12 @@ module.exports = {
 			format: "esm",
 		},
 	],
-	external: ["react", "@emotion/core", "@emotion/css"],
+	external: [
+		"react",
+		"@emotion/core",
+		"@emotion/css",
+		"@guardian/src-foundations",
+		"@guardian/src-foundations/accessibility",
+	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/packages/text-input/README.md
+++ b/packages/text-input/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 ```sh
-$ yarn add @guardian/src-text-input
+$ yarn add @guardian/src-text-input @guardian/src-foundations
 ```
 
 ## Use

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -4,7 +4,7 @@
 	"main": "dist/text-input.js",
 	"module": "dist/text-input.esm.js",
 	"scripts": {
-		"build": "rollup --config",
+		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
 		"prepublish": "yarn build"
 	},
@@ -14,6 +14,8 @@
 		"@babel/preset-react": "^7.0.0",
 		"@babel/preset-typescript": "^7.3.3",
 		"@emotion/babel-preset-css-prop": "^10.0.14",
+		"@guardian/src-foundations": "^0.5.0",
+		"@guardian/src-helpers": "^0.0.1",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
 		"rollup-plugin-commonjs": "^10.0.2",
@@ -26,11 +28,10 @@
 	],
 	"peerDependencies": {
 		"@emotion/core": "^10.0.14",
+		"@guardian/src-foundations": "^0.5.0",
 		"react": "^16.8.6"
 	},
 	"dependencies": {
-		"@guardian/src-foundations": "^0.5.0",
-		"@guardian/src-helpers": "^0.0.1",
 		"@guardian/src-inline-error": "^0.0.4",
 		"@guardian/src-svgs": "^0.0.2"
 	}

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-text-input",
-	"version": "0.0.2",
+	"version": "0.1.0",
 	"main": "dist/text-input.js",
 	"module": "dist/text-input.esm.js",
 	"scripts": {

--- a/packages/text-input/rollup.config.js
+++ b/packages/text-input/rollup.config.js
@@ -16,6 +16,12 @@ module.exports = {
 			format: "esm",
 		},
 	],
-	external: ["react", "@emotion/core", "@emotion/css"],
+	external: [
+		"react",
+		"@emotion/core",
+		"@emotion/css",
+		"@guardian/src-foundations",
+		"@guardian/src-foundations/accessibility",
+	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -4,7 +4,7 @@
 	"main": "dist/utilities.js",
 	"module": "dist/utilities.esm.js",
 	"scripts": {
-		"build": "rollup --config",
+		"build": "yarn clean && rollup --config",
 		"watch": "rollup --config --watch",
 		"clean": "rm -rf dist",
 		"prepublish": "yarn build"


### PR DESCRIPTION
## What is the purpose of this change?

Every component currently brings its own version of src-foundations, which leads to a lot of duplicated code. This change ensures src-foundations is an external dependency, a direct dependency of the consuming project.

## What does this change?

- Makes src-foundations a peer dependency of every component
- Make src-foundations an external module of every component's build process
- Updates docs for each component
- Bumps every component version

### Bonus tasks

- Adds clean to each build script
- Adds missing text-input build script to root build script
