### PR TITLE
Update typography API

### DIFF
--- a/packages/foundations/.gitignore
+++ b/packages/foundations/.gitignore
@@ -1,5 +1,12 @@
+# Ignore built files
 mq/
 accessibility/
+__typography/
 foundations.js
 foundations.esm.js
 *.d.ts
+
+# Include src files
+!src/mq/
+!src/accessibility/
+!src/__typography/

--- a/packages/foundations/package.json
+++ b/packages/foundations/package.json
@@ -6,13 +6,14 @@
 	"scripts": {
 		"build": "yarn clean && tsc && rollup --config",
 		"watch": "rollup --config --watch",
-		"clean": "rm -rf accessibility mq foundations.js foundations.esm.js *.d.ts src/**/*.d.ts",
+		"clean": "rm -rf accessibility mq __typography foundations.js foundations.esm.js *.d.ts src/**/*.d.ts",
 		"prepublishOnly": "yarn build",
 		"postpublish": "yarn clean"
 	},
 	"files": [
 		"mq/*",
 		"accessibility/*",
+		"__typography/*",
 		"*.d.ts",
 		"foundations.esm.js",
 		"src/animation.ts",
@@ -24,7 +25,8 @@
 		"src/theme.ts",
 		"src/typography.ts",
 		"src/accessibility/index.ts",
-		"src/mq/index.ts"
+		"src/mq/index.ts",
+		"src/typography/index.ts"
 	],
 	"devDependencies": {
 		"@babel/preset-env": "^7.5.5",

--- a/packages/foundations/rollup.config.js
+++ b/packages/foundations/rollup.config.js
@@ -3,6 +3,17 @@ import resolve from "rollup-plugin-node-resolve"
 
 const extensions = [".ts", ".tsx"]
 const plugins = [babel({ extensions }), resolve({ extensions })]
+const folders = ["accessibility", "mq", "__typography"].map(folder => ({
+	input: `src/${folder}/index.ts`,
+	output: [
+		{
+			file: `${folder}/index.js`,
+			format: "cjs",
+		},
+	],
+	plugins,
+	external: ["@guardian/src-foundations"],
+}))
 
 module.exports = [
 	{
@@ -19,26 +30,5 @@ module.exports = [
 		],
 		plugins,
 	},
-	{
-		input: "src/mq/index.ts",
-		output: [
-			{
-				file: "mq/index.js",
-				format: "cjs",
-			},
-		],
-		plugins,
-		external: ["@guardian/src-foundations"],
-	},
-	{
-		input: "src/accessibility/index.ts",
-		output: [
-			{
-				file: "accessibility/index.js",
-				format: "cjs",
-			},
-		],
-		plugins,
-		external: ["@guardian/src-foundations"],
-	},
+	...folders,
 ]

--- a/packages/foundations/src/__typography/index.ts
+++ b/packages/foundations/src/__typography/index.ts
@@ -1,0 +1,246 @@
+import { fontSizes, fonts, lineHeights, fontWeights } from "../theme"
+
+type Category = "headline" | "body" | "textSans"
+type LineHeight = "tight" | "regular" | "loose"
+type FontWeight = "light" | "regular" | "medium" | "bold"
+type FontWeightDefinition = { fontWeight: number; hasItalic: boolean }
+
+type HeadlineSizes =
+	| "tiny"
+	| "xxsmall"
+	| "xsmall"
+	| "small"
+	| "medium"
+	| "large"
+	| "xlarge"
+	| "jumbo"
+
+type BodySizes = "small" | "medium"
+
+type TextSansSizes =
+	| "xsmall"
+	| "small"
+	| "medium"
+	| "large"
+	| "xlarge"
+	| "xxlarge"
+
+const fontSizesRem = fontSizes.map(fontSize => fontSize / 16)
+
+const headlineSizes: { [key in HeadlineSizes]: number } = {
+	tiny: fontSizesRem[2], //17px
+	// BEGIN SUGGESTED RANGE
+	xxsmall: fontSizesRem[3], //20px
+	xsmall: fontSizesRem[4], //24px
+	small: fontSizesRem[5], //28px
+	medium: fontSizesRem[6], //34px
+	large: fontSizesRem[7], //42px
+	xlarge: fontSizesRem[8], //50px
+	// END SUGGESTED RANGE
+	jumbo: fontSizesRem[9], //70px
+}
+
+const bodySizes: { [key in BodySizes]: number } = {
+	small: fontSizesRem[1], //15px
+	medium: fontSizesRem[2], //17px
+}
+
+const textSansSizes: { [key in TextSansSizes]: number } = {
+	// BEGIN SUGGESTED RANGE
+	xsmall: fontSizesRem[0], //12px
+	small: fontSizesRem[1], //15px
+	medium: fontSizesRem[2], //17px
+	// END SUGGESTED RANGE
+	large: fontSizesRem[3], //20px
+	xlarge: fontSizesRem[4], //24px
+	xxlarge: fontSizesRem[5], //28px
+	// xxxlarge: fontSizesRem[6], //34px
+	// xxxxlarge: fontSizesRem[7], //42px
+	// xxxxxlarge: fontSizesRem[8], //50px
+	// xxxxxxlarge: fontSizesRem[9], //70px
+}
+
+const fontSizeMapping: { [cat in Category]: { [level in string]: number } } = {
+	headline: headlineSizes,
+	body: bodySizes,
+	textSans: textSansSizes,
+}
+
+const fontMapping: { [cat in Category]: string } = {
+	headline: fonts.headlineSerif,
+	body: fonts.bodySerif,
+	textSans: fonts.bodySans,
+}
+
+const lineHeightMapping: { [lineHight in LineHeight]: string } = {
+	tight: lineHeights[0],
+	regular: lineHeights[1],
+	loose: lineHeights[2],
+}
+
+const fontWeightMapping: {
+	[cat in Category]: {
+		[fontWeight in FontWeight]?: FontWeightDefinition
+	}
+} = {
+	headline: {
+		light: {
+			fontWeight: fontWeights[0],
+			hasItalic: true,
+		},
+		medium: {
+			fontWeight: fontWeights[2],
+			hasItalic: true,
+		},
+		bold: {
+			fontWeight: fontWeights[3],
+			hasItalic: false,
+		},
+	},
+	body: {
+		regular: {
+			fontWeight: fontWeights[1],
+			hasItalic: true,
+		},
+		bold: {
+			fontWeight: fontWeights[3],
+			hasItalic: true,
+		},
+	},
+	textSans: {
+		regular: {
+			fontWeight: fontWeights[1],
+			hasItalic: true,
+		},
+		bold: {
+			fontWeight: fontWeights[3],
+			hasItalic: false,
+		},
+	},
+}
+
+const fs = ({
+	category,
+	level,
+	lineHeight,
+	fontWeight,
+}: {
+	category: Category
+	level: string
+	lineHeight: LineHeight
+	fontWeight: FontWeight
+}) => {
+	const fontFamilyValue = fontMapping[category]
+	const fontSizeValue = fontSizeMapping[category][level]
+	const lineHeightValue = lineHeightMapping[lineHeight]
+	const fontWeightDefinition = fontWeightMapping[category][fontWeight]
+
+	return `
+	font-family: ${fontFamilyValue};
+	font-size: ${fontSizeValue}rem;
+	line-height: ${lineHeightValue};
+	${
+		fontWeightDefinition
+			? `font-weight: ${fontWeightDefinition.fontWeight}`
+			: ""
+	};
+	`
+}
+
+interface FontScaleArgs {
+	lineHeight?: LineHeight
+	fontWeight?: FontWeight
+}
+
+type HeadlineFunctions = {
+	[key in HeadlineSizes]: (options?: FontScaleArgs) => number
+}
+
+const headline: HeadlineFunctions = Object.keys(headlineSizes).reduce(
+	(acc, key) => {
+		return Object.assign({}, acc, {
+			[key]: (options: FontScaleArgs) => {
+				const defaultOptions = {
+					lineHeight: "tight",
+					fontWeight: "medium",
+				}
+				const { lineHeight, fontWeight } = Object.assign(
+					defaultOptions,
+					options,
+				)
+
+				return fs({
+					category: "headline",
+					level: key,
+					lineHeight,
+					fontWeight,
+				})
+			},
+		})
+	},
+	{} as HeadlineFunctions,
+)
+
+type BodyFunctions = {
+	[key in BodySizes]: (options?: FontScaleArgs) => number
+}
+
+const body: BodyFunctions = Object.keys(bodySizes).reduce(
+	(acc, key) => {
+		return Object.assign({}, acc, {
+			[key]: (options: FontScaleArgs) => {
+				const defaultOptions = {
+					lineHeight: "loose",
+					fontWeight: "regular",
+				}
+				const { lineHeight, fontWeight } = Object.assign(
+					defaultOptions,
+					options,
+				)
+
+				return fs({
+					category: "body",
+					level: key,
+					lineHeight,
+					fontWeight,
+				})
+			},
+		})
+	},
+	{} as BodyFunctions,
+)
+
+type TextSansFunctions = {
+	[key in TextSansSizes]: (options?: FontScaleArgs) => number
+}
+
+const textSans: TextSansFunctions = Object.keys(textSansSizes).reduce(
+	(acc, key) => {
+		return Object.assign({}, acc, {
+			[key]: (options: FontScaleArgs) => {
+				const defaultOptions = {
+					lineHeight: "loose",
+					fontWeight: "regular",
+				}
+				const { lineHeight, fontWeight } = Object.assign(
+					defaultOptions,
+					options,
+				)
+
+				return fs({
+					category: "textSans",
+					level: key,
+					lineHeight,
+					fontWeight,
+				})
+			},
+		})
+	},
+	{} as TextSansFunctions,
+)
+
+Object.freeze(headlineSizes)
+Object.freeze(bodySizes)
+Object.freeze(textSansSizes)
+
+export { headline, body, textSans, headlineSizes, bodySizes, textSansSizes }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,14 @@
 	"compilerOptions": {
 		"baseUrl": "./packages",
 		"paths": {
-			"@guardian/src-foundations": ["foundations"],
-			"@guardian/src-foundations/mq": ["foundations/mq"],
+			"@guardian/src-foundations": ["foundations/src"],
+			"@guardian/src-foundations/mq": ["foundations/src/mq"],
+			"@guardian/src-foundations/accessibility": [
+				"foundations/src/accessibility"
+			],
+			"@guardian/src-foundations/__typography": [
+				"foundations/src/__typography"
+			],
 			"@guardian/inline-error": ["inline-error"],
 			"@guardian/src-helpers": ["helpers"],
 			"@guardian/src-svgs": ["svgs"]


### PR DESCRIPTION
## What is the purpose of this change?

### Old API

```js
import { headline } from "@guardian/src-foundations"

const styles = css`
  ${headline({ level: 5, fontWeight: 'bold' })}
`
```

After some discussion about the typography API, there was consensus that:

- `level` was not a very descriptive concept
- levels as numbers was difficult to decode at a glance
- specifying `fontWeight` and `lineHeight` as options is readable and extensible

## What does this change?

Provides a new API for typography. This is exposed under the `__typography` folder (the double-underscore denotes experimental) 

### New API

```js
import { headline } from "@guardian/src-foundations/__typography"

const styles = css`
  ${headline.medium({ fontWeight: 'bold' })}
`
```

If no options are specified, sensible defaults are provided
