### PR TITLE
Run validate and build on CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,8 +14,8 @@ jobs:
             - name: build
               run: |
                   yarn
-                  yarn lint
-                  yarn build
+                  yarn validate
+                  yarn ci:build
             - name: deploy
               env:
                   GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,5 @@ jobs:
             - name: build
               run: |
                   yarn
-                  yarn lint
-                  yarn build
+                  yarn validate
+                  yarn ci:build

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"build:inline-error": "cd packages/inline-error && yarn build",
 		"build:radio": "cd packages/radio && yarn build",
 		"build:text-input": "cd packages/text-input && yarn build",
-		"build": "NODE_ENV=production yarn build:storybook && yarn build:foundations && yarn build:utilities && yarn build:svgs && yarn build:button && yarn build:inline-error && yarn build:radio && yarn build:text-input"
+		"ci:build": "NODE_ENV=production yarn build:storybook && yarn build:foundations && yarn build:utilities && yarn build:svgs && yarn build:button && yarn build:inline-error && yarn build:radio && yarn build:text-input"
 	},
 	"private": true,
 	"workspaces": [


### PR DESCRIPTION
## What is the purpose of this change?

Type checking doesn't currently happen on CI/CD.

## What does this change?

Runs the `validate` script on CI and CD, ensuring types are checked and code is linted.

This change also updates the name of the `build` script to make it clearer that the intention is that it should only be run on CI / CD.
