### PR TITLE
Typography readme

### DIFF
--- a/packages/foundations/README.md
+++ b/packages/foundations/README.md
@@ -20,6 +20,24 @@ const backgroundColor = css`
 `
 ```
 
+### [Typography](https://zeroheight.com/2a1e5182b/p/930d69)
+
+```ts
+import { headline, body textSans } from "@guardian/src-foundations/typography"
+
+const h1 = css`
+    ${headline.large({ fontWeight: 'bold' })};
+`
+
+const p = css`
+    ${body.main()};
+`
+
+const copyright = css`
+    ${textSans.xsmall()};
+`
+```
+
 ### Media queries
 
 ```ts


### PR DESCRIPTION
## What is the purpose of this change?

There is a need for some typography docs

## What does this change?

Adds a rudimentary readme describing the API of the typography module

