### PR TITLE
TextInput error message can only be a string

### DIFF
--- a/packages/text-input/README.md
+++ b/packages/text-input/README.md
@@ -54,6 +54,6 @@ the width will default to 100% of the field's container.
 
 ### `error`
 
-**`boolean | string`**
+**`string`**
 
-Whether error styling should apply to this text input. If a string is passed, this appears as an inline error message
+Whether error styling should apply to this text input. The string appears as an inline error message.

--- a/packages/text-input/index.tsx
+++ b/packages/text-input/index.tsx
@@ -39,7 +39,7 @@ const TextInput = ({
 	optional: boolean
 	supporting?: string
 	width?: Width
-	error: boolean | string
+	error?: string
 }) => {
 	return (
 		<label>
@@ -48,7 +48,7 @@ const TextInput = ({
 				{optional ? <span css={optionalLabel}>Optional</span> : ""}
 			</div>
 			{supporting ? <SupportingText>{supporting}</SupportingText> : ""}
-			{typeof error === "string" && <InlineError>{error}</InlineError>}
+			{error && <InlineError>{error}</InlineError>}
 			<input
 				css={theme => [
 					width ? widths[width] : widthFluid,
@@ -65,7 +65,6 @@ const defaultProps = {
 	disabled: false,
 	type: "text",
 	optional: false,
-	error: false,
 }
 
 TextInput.defaultProps = { ...defaultProps }

--- a/packages/text-input/stories.tsx
+++ b/packages/text-input/stories.tsx
@@ -169,38 +169,10 @@ const [errorWithMessageLight] = appearances.map(
 	},
 )
 
-const [errorWithoutMessageLight] = appearances.map(
-	({ name, theme }: { name: Appearance; theme: {} }) => {
-		const story = () => (
-			<ThemeProvider theme={theme}>
-				<div css={constrainedWith}>
-					<TextInput label="First name" error={true} />
-				</div>
-			</ThemeProvider>
-		)
-
-		story.story = {
-			name: `error without message ${name}`,
-			parameters: {
-				backgrounds: [
-					Object.assign(
-						{},
-						{ default: true },
-						storybookBackgrounds[name],
-					),
-				],
-			},
-		}
-
-		return story
-	},
-)
-
 export {
 	defaultLight,
 	optionalLight,
 	supportingTextLight,
 	widthsLight,
 	errorWithMessageLight,
-	errorWithoutMessageLight,
 }


### PR DESCRIPTION
## What is the purpose of this change?

Currently, the TextInput may be styled with error styling, but without an error message. This is confusing and not a pattern we wish to encourage

## What does this change?

Removes support for an `error` boolean. This prop can now only be a string, that will display above the input field when the element is in an error state.
