### PR TITLE
Add Titlepiece to typography API

### DIFF
--- a/packages/foundations/src/theme.ts
+++ b/packages/foundations/src/theme.ts
@@ -1,6 +1,7 @@
 const fontSizes = [12, 15, 17, 20, 24, 28, 34, 42, 50, 70]
 
 const fonts = {
+	titlepiece: "GT Guardian Titlepiece, Georgia, serif",
 	headlineSerif: "GH Guardian Headline, Georgia, serif",
 	bodySerif: "GuardianTextEgyptian, Georgia, serif",
 	bodySans:


### PR DESCRIPTION
## What is the purpose of this change?

Titlepiece is not currently exposed via the typography API, but it is needed for some products.

## What does this change?

- Adds Titlepiece to the API
- Some refactoring to make it easier to determine the available fonts
