### PR TITLE
Add themes to src-foundations

### DIFF
--- a/packages/foundations/.gitignore
+++ b/packages/foundations/.gitignore
@@ -1,6 +1,7 @@
 # Ignore built files
 mq/
 accessibility/
+themes/
 typography/
 foundations.js
 foundations.esm.js
@@ -10,4 +11,5 @@ foundations.esm.js
 # Include src files
 !src/mq/
 !src/accessibility/
+!src/themes/
 !src/typography/

--- a/packages/foundations/package.json
+++ b/packages/foundations/package.json
@@ -13,6 +13,7 @@
 	"files": [
 		"mq/*",
 		"accessibility/*",
+		"themes/*",
 		"typography/*",
 		"*.d.ts",
 		"foundations.esm.js",
@@ -25,6 +26,7 @@
 		"src/theme.ts",
 		"src/accessibility/index.ts",
 		"src/mq/index.ts",
+		"src/themes/**",
 		"src/typography/index.ts"
 	],
 	"devDependencies": {

--- a/packages/foundations/rollup.config.js
+++ b/packages/foundations/rollup.config.js
@@ -3,7 +3,7 @@ import resolve from "rollup-plugin-node-resolve"
 
 const extensions = [".ts", ".tsx"]
 const plugins = [babel({ extensions }), resolve({ extensions })]
-const folders = ["accessibility", "mq", "typography"].map(folder => ({
+const folders = ["accessibility", "mq", "themes", "typography"].map(folder => ({
 	input: `src/${folder}/index.ts`,
 	output: [
 		{

--- a/packages/foundations/src/themes/button.ts
+++ b/packages/foundations/src/themes/button.ts
@@ -1,0 +1,106 @@
+import { palette } from "../index"
+
+export type ButtonTheme = {
+	backgroundColorPrimary: string
+	textColorPrimary: string
+	backgroundColorPrimaryHover: string
+	backgroundColorSecondary: string
+	textColorSecondary: string
+	backgroundColorSecondaryHover: string
+	borderColorSecondary?: string
+	backgroundColorTertiary?: string
+	textColorTertiary?: string
+}
+
+// light
+export const buttonDefault: { button: ButtonTheme } = {
+	button: {
+		backgroundColorPrimary: palette.brand.main,
+		textColorPrimary: palette.neutral[100],
+		backgroundColorPrimaryHover: "#234B8A",
+		backgroundColorSecondary: palette.brand.faded,
+		textColorSecondary: palette.brand.main,
+		backgroundColorSecondaryHover: "#96B0D9",
+		backgroundColorTertiary: palette.neutral[100],
+		textColorTertiary: palette.brand.main,
+	},
+}
+
+// dark
+export const buttonInverse: { button: ButtonTheme } = {
+	button: {
+		backgroundColorPrimary: palette.neutral[100],
+		textColorPrimary: palette.neutral[7],
+		backgroundColorPrimaryHover: palette.neutral[93],
+		backgroundColorSecondary: palette.neutral[46],
+		textColorSecondary: palette.neutral[100],
+		backgroundColorSecondaryHover: "#5C5C5C",
+		backgroundColorTertiary: palette.neutral.darkMode,
+		textColorTertiary: palette.neutral[100],
+	},
+}
+
+// brand blue
+export const buttonBrand: { button: ButtonTheme } = {
+	button: {
+		backgroundColorPrimary: palette.neutral[100],
+		textColorPrimary: palette.brand.main,
+		backgroundColorPrimaryHover: palette.neutral[93],
+		backgroundColorSecondary: palette.brand.pastel,
+		textColorSecondary: palette.neutral[100],
+		backgroundColorSecondaryHover: "#234B8A",
+		backgroundColorTertiary: palette.brand.main,
+		textColorTertiary: palette.neutral[100],
+	},
+}
+
+// yellow
+export const buttonBrandInverse: { button: ButtonTheme } = {
+	button: {
+		backgroundColorPrimary: palette.neutral[7],
+		textColorPrimary: palette.neutral[100],
+		backgroundColorPrimaryHover: palette.neutral[20],
+		backgroundColorSecondary: palette.yellow.dark,
+		textColorSecondary: palette.neutral[7],
+		backgroundColorSecondaryHover: "#F2AE00",
+		backgroundColorTertiary: palette.yellow.main,
+		textColorTertiary: palette.neutral[7],
+	},
+}
+
+// reader revenue blue
+export const buttonReaderRevenue: { button: ButtonTheme } = {
+	button: {
+		backgroundColorPrimary: palette.yellow.main,
+		textColorPrimary: palette.brand.main,
+		backgroundColorPrimaryHover: palette.yellow.dark,
+		backgroundColorSecondary: palette.brand.main,
+		textColorSecondary: palette.yellow.main,
+		backgroundColorSecondaryHover: palette.brand.dark,
+		borderColorSecondary: palette.yellow.main,
+	},
+}
+
+// reader revenue yellow
+export const buttonReaderRevenueInverse: { button: ButtonTheme } = {
+	button: {
+		backgroundColorPrimary: palette.neutral[7],
+		textColorPrimary: palette.neutral[100],
+		backgroundColorPrimaryHover: palette.neutral[20],
+		backgroundColorSecondary: palette.yellow.main,
+		textColorSecondary: palette.neutral[7],
+		backgroundColorSecondaryHover: palette.yellow.dark,
+		borderColorSecondary: palette.neutral[7],
+		backgroundColorTertiary: palette.neutral[100],
+		textColorTertiary: palette.brand.main,
+	},
+}
+
+export const button = {
+	buttonDefault,
+	buttonInverse,
+	buttonBrand,
+	buttonBrandInverse,
+	buttonReaderRevenue,
+	buttonReaderRevenueInverse,
+}

--- a/packages/foundations/src/themes/button.ts
+++ b/packages/foundations/src/themes/button.ts
@@ -1,98 +1,98 @@
 import { palette } from "../index"
 
 export type ButtonTheme = {
-	backgroundColorPrimary: string
-	textColorPrimary: string
-	backgroundColorPrimaryHover: string
-	backgroundColorSecondary: string
-	textColorSecondary: string
-	backgroundColorSecondaryHover: string
-	borderColorSecondary?: string
-	backgroundColorTertiary?: string
-	textColorTertiary?: string
+	backgroundPrimary: string
+	textPrimary: string
+	backgroundPrimaryHover: string
+	backgroundSecondary: string
+	textSecondary: string
+	backgroundSecondaryHover: string
+	borderSecondary?: string
+	backgroundTertiary?: string
+	textTertiary?: string
 }
 
 // light
 export const buttonDefault: { button: ButtonTheme } = {
 	button: {
-		backgroundColorPrimary: palette.brand.main,
-		textColorPrimary: palette.neutral[100],
-		backgroundColorPrimaryHover: "#234B8A",
-		backgroundColorSecondary: palette.brand.faded,
-		textColorSecondary: palette.brand.main,
-		backgroundColorSecondaryHover: "#96B0D9",
-		backgroundColorTertiary: palette.neutral[100],
-		textColorTertiary: palette.brand.main,
+		backgroundPrimary: palette.brand.main,
+		textPrimary: palette.neutral[100],
+		backgroundPrimaryHover: "#234B8A",
+		backgroundSecondary: palette.brand.faded,
+		textSecondary: palette.brand.main,
+		backgroundSecondaryHover: "#96B0D9",
+		backgroundTertiary: palette.neutral[100],
+		textTertiary: palette.brand.main,
 	},
 }
 
 // dark
 export const buttonInverse: { button: ButtonTheme } = {
 	button: {
-		backgroundColorPrimary: palette.neutral[100],
-		textColorPrimary: palette.neutral[7],
-		backgroundColorPrimaryHover: palette.neutral[93],
-		backgroundColorSecondary: palette.neutral[46],
-		textColorSecondary: palette.neutral[100],
-		backgroundColorSecondaryHover: "#5C5C5C",
-		backgroundColorTertiary: palette.neutral.darkMode,
-		textColorTertiary: palette.neutral[100],
+		backgroundPrimary: palette.neutral[100],
+		textPrimary: palette.neutral[7],
+		backgroundPrimaryHover: palette.neutral[93],
+		backgroundSecondary: palette.neutral[46],
+		textSecondary: palette.neutral[100],
+		backgroundSecondaryHover: "#5C5C5C",
+		backgroundTertiary: palette.neutral.darkMode,
+		textTertiary: palette.neutral[100],
 	},
 }
 
 // brand blue
 export const buttonBrand: { button: ButtonTheme } = {
 	button: {
-		backgroundColorPrimary: palette.neutral[100],
-		textColorPrimary: palette.brand.main,
-		backgroundColorPrimaryHover: palette.neutral[93],
-		backgroundColorSecondary: palette.brand.pastel,
-		textColorSecondary: palette.neutral[100],
-		backgroundColorSecondaryHover: "#234B8A",
-		backgroundColorTertiary: palette.brand.main,
-		textColorTertiary: palette.neutral[100],
+		backgroundPrimary: palette.neutral[100],
+		textPrimary: palette.brand.main,
+		backgroundPrimaryHover: palette.neutral[93],
+		backgroundSecondary: palette.brand.pastel,
+		textSecondary: palette.neutral[100],
+		backgroundSecondaryHover: "#234B8A",
+		backgroundTertiary: palette.brand.main,
+		textTertiary: palette.neutral[100],
 	},
 }
 
 // yellow
 export const buttonBrandInverse: { button: ButtonTheme } = {
 	button: {
-		backgroundColorPrimary: palette.neutral[7],
-		textColorPrimary: palette.neutral[100],
-		backgroundColorPrimaryHover: palette.neutral[20],
-		backgroundColorSecondary: palette.yellow.dark,
-		textColorSecondary: palette.neutral[7],
-		backgroundColorSecondaryHover: "#F2AE00",
-		backgroundColorTertiary: palette.yellow.main,
-		textColorTertiary: palette.neutral[7],
+		backgroundPrimary: palette.neutral[7],
+		textPrimary: palette.neutral[100],
+		backgroundPrimaryHover: palette.neutral[20],
+		backgroundSecondary: palette.yellow.dark,
+		textSecondary: palette.neutral[7],
+		backgroundSecondaryHover: "#F2AE00",
+		backgroundTertiary: palette.yellow.main,
+		textTertiary: palette.neutral[7],
 	},
 }
 
 // reader revenue blue
 export const buttonReaderRevenue: { button: ButtonTheme } = {
 	button: {
-		backgroundColorPrimary: palette.yellow.main,
-		textColorPrimary: palette.brand.main,
-		backgroundColorPrimaryHover: palette.yellow.dark,
-		backgroundColorSecondary: palette.brand.main,
-		textColorSecondary: palette.yellow.main,
-		backgroundColorSecondaryHover: palette.brand.dark,
-		borderColorSecondary: palette.yellow.main,
+		backgroundPrimary: palette.yellow.main,
+		textPrimary: palette.brand.main,
+		backgroundPrimaryHover: palette.yellow.dark,
+		backgroundSecondary: palette.brand.main,
+		textSecondary: palette.yellow.main,
+		backgroundSecondaryHover: palette.brand.dark,
+		borderSecondary: palette.yellow.main,
 	},
 }
 
 // reader revenue yellow
 export const buttonReaderRevenueInverse: { button: ButtonTheme } = {
 	button: {
-		backgroundColorPrimary: palette.neutral[7],
-		textColorPrimary: palette.neutral[100],
-		backgroundColorPrimaryHover: palette.neutral[20],
-		backgroundColorSecondary: palette.yellow.main,
-		textColorSecondary: palette.neutral[7],
-		backgroundColorSecondaryHover: palette.yellow.dark,
-		borderColorSecondary: palette.neutral[7],
-		backgroundColorTertiary: palette.neutral[100],
-		textColorTertiary: palette.brand.main,
+		backgroundPrimary: palette.neutral[7],
+		textPrimary: palette.neutral[100],
+		backgroundPrimaryHover: palette.neutral[20],
+		backgroundSecondary: palette.yellow.main,
+		textSecondary: palette.neutral[7],
+		backgroundSecondaryHover: palette.yellow.dark,
+		borderSecondary: palette.neutral[7],
+		backgroundTertiary: palette.neutral[100],
+		textTertiary: palette.brand.main,
 	},
 }
 

--- a/packages/foundations/src/themes/index.ts
+++ b/packages/foundations/src/themes/index.ts
@@ -1,3 +1,4 @@
 export * from "./button"
 export * from "./inline-error"
 export * from "./radio"
+export * from "./text-input"

--- a/packages/foundations/src/themes/index.ts
+++ b/packages/foundations/src/themes/index.ts
@@ -1,0 +1,3 @@
+export * from "./button"
+export * from "./inline-error"
+export * from "./radio"

--- a/packages/foundations/src/themes/inline-error.ts
+++ b/packages/foundations/src/themes/inline-error.ts
@@ -1,0 +1,17 @@
+import { palette } from "../index"
+
+export type InlineErrorTheme = {
+	textColor: string
+}
+
+export const inlineErrorDefault: { inlineError: InlineErrorTheme } = {
+	inlineError: {
+		textColor: palette.error.main,
+	},
+}
+
+export const inlineErrorBrand: { inlineError: InlineErrorTheme } = {
+	inlineError: {
+		textColor: palette.error.bright,
+	},
+}

--- a/packages/foundations/src/themes/inline-error.ts
+++ b/packages/foundations/src/themes/inline-error.ts
@@ -1,17 +1,17 @@
 import { palette } from "../index"
 
 export type InlineErrorTheme = {
-	textColor: string
+	text: string
 }
 
 export const inlineErrorDefault: { inlineError: InlineErrorTheme } = {
 	inlineError: {
-		textColor: palette.error.main,
+		text: palette.error.main,
 	},
 }
 
 export const inlineErrorBrand: { inlineError: InlineErrorTheme } = {
 	inlineError: {
-		textColor: palette.error.bright,
+		text: palette.error.bright,
 	},
 }

--- a/packages/foundations/src/themes/radio.ts
+++ b/packages/foundations/src/themes/radio.ts
@@ -1,0 +1,46 @@
+import { palette } from "../index"
+import {
+	inlineErrorDefault,
+	inlineErrorBrand,
+	InlineErrorTheme,
+} from "./inline-error"
+
+export type RadioTheme = {
+	hoverBorderColor: string
+	// this name needs some thought!
+	color: string
+	checkedColor: string
+	textColor: string
+	textColorSupporting: string
+	textColorError: string
+}
+
+export const radioDefault: {
+	radio: RadioTheme
+	inlineError: InlineErrorTheme
+} = {
+	radio: {
+		hoverBorderColor: palette.brand.main,
+		color: palette.neutral[60],
+		checkedColor: palette.brand.main,
+		textColor: palette.neutral[20],
+		textColorSupporting: palette.neutral[46],
+		textColorError: palette.error.main,
+	},
+	...inlineErrorDefault,
+}
+
+export const radioBrand: {
+	radio: RadioTheme
+	inlineError: InlineErrorTheme
+} = {
+	radio: {
+		hoverBorderColor: palette.neutral[100],
+		color: palette.brand.faded,
+		checkedColor: palette.neutral[100],
+		textColor: palette.neutral[100],
+		textColorSupporting: palette.brand.faded,
+		textColorError: palette.error.bright,
+	},
+	...inlineErrorBrand,
+}

--- a/packages/foundations/src/themes/radio.ts
+++ b/packages/foundations/src/themes/radio.ts
@@ -6,13 +6,13 @@ import {
 } from "./inline-error"
 
 export type RadioTheme = {
-	hoverBorderColor: string
+	borderHover: string
 	// this name needs some thought!
 	color: string
-	checkedColor: string
-	textColor: string
-	textColorSupporting: string
-	textColorError: string
+	checked: string
+	text: string
+	textSupporting: string
+	textError: string
 }
 
 export const radioDefault: {
@@ -20,12 +20,12 @@ export const radioDefault: {
 	inlineError: InlineErrorTheme
 } = {
 	radio: {
-		hoverBorderColor: palette.brand.main,
+		borderHover: palette.brand.main,
 		color: palette.neutral[60],
-		checkedColor: palette.brand.main,
-		textColor: palette.neutral[20],
-		textColorSupporting: palette.neutral[46],
-		textColorError: palette.error.main,
+		checked: palette.brand.main,
+		text: palette.neutral[20],
+		textSupporting: palette.neutral[46],
+		textError: palette.error.main,
 	},
 	...inlineErrorDefault,
 }
@@ -35,12 +35,12 @@ export const radioBrand: {
 	inlineError: InlineErrorTheme
 } = {
 	radio: {
-		hoverBorderColor: palette.neutral[100],
+		borderHover: palette.neutral[100],
 		color: palette.brand.faded,
-		checkedColor: palette.neutral[100],
-		textColor: palette.neutral[100],
-		textColorSupporting: palette.brand.faded,
-		textColorError: palette.error.bright,
+		checked: palette.neutral[100],
+		text: palette.neutral[100],
+		textSupporting: palette.brand.faded,
+		textError: palette.error.bright,
 	},
 	...inlineErrorBrand,
 }

--- a/packages/foundations/src/themes/text-input.ts
+++ b/packages/foundations/src/themes/text-input.ts
@@ -1,0 +1,20 @@
+import { palette } from "../index"
+import { inlineErrorDefault, InlineErrorTheme } from "./inline-error"
+
+export type TextInputTheme = {
+	textColorInput: string
+	textColorLabel: string
+	backgroundColor: string
+}
+
+export const textInputDefault: {
+	textInput: TextInputTheme
+	inlineError: InlineErrorTheme
+} = {
+	textInput: {
+		textColorInput: palette.neutral[7],
+		textColorLabel: palette.neutral[20],
+		backgroundColor: palette.neutral[100],
+	},
+	...inlineErrorDefault,
+}

--- a/packages/foundations/src/themes/text-input.ts
+++ b/packages/foundations/src/themes/text-input.ts
@@ -2,9 +2,9 @@ import { palette } from "../index"
 import { inlineErrorDefault, InlineErrorTheme } from "./inline-error"
 
 export type TextInputTheme = {
-	textColorInput: string
-	textColorLabel: string
-	backgroundColor: string
+	textInput: string
+	textLabel: string
+	backgroundInput: string
 }
 
 export const textInputDefault: {
@@ -12,9 +12,9 @@ export const textInputDefault: {
 	inlineError: InlineErrorTheme
 } = {
 	textInput: {
-		textColorInput: palette.neutral[7],
-		textColorLabel: palette.neutral[20],
-		backgroundColor: palette.neutral[100],
+		textInput: palette.neutral[7],
+		textLabel: palette.neutral[20],
+		backgroundInput: palette.neutral[100],
 	},
 	...inlineErrorDefault,
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
 			"@guardian/src-foundations/accessibility": [
 				"foundations/src/accessibility"
 			],
+			"@guardian/src-foundations/themes": ["foundations/src/themes"],
 			"@guardian/src-foundations/typography": [
 				"foundations/src/typography"
 			],


### PR DESCRIPTION
## What is the purpose of this change?

Themes are an extension of the palette and as such belong in `src-foundations`. This makes them easier to compose: it allows the consumer to import themes for all components in one statement and pass them to the `<ThemeProvider>` at the top of the application.

## What does this change?

Adds a themes folder under `src-foundations`. There is one module per package. The currently supported themes are:

- `default` - light mode (i.e. white background)
- `inverse` - dark mode (i.e. dark background)
- `brand` - brand blue background
- `brandInverse` - yellow background
- `readerRevenue` - reader revenue blue background
- `readerRevenueInverse` - reader revenue yellow background

Token names under a theme are constructed using the following pattern:

- the colour property that will be adjusted (`text`, `background`, ...)
- the variant (`primary`, `secondary`, ...)
- the component state (`hover`, `checked`, ...)

This roughly follows the naming conventions used by [Salesforce](https://www.lightningdesignsystem.com/design-tokens/). Specifying our tokens under `themes` means we don't need to include the component name in the token name. Also the word `color`  would be redundant and so is omitted.