### PR TITLE
Upgrade foundations to Typescript 3.7.2

### DIFF
--- a/packages/foundations/package.json
+++ b/packages/foundations/package.json
@@ -35,6 +35,6 @@
 		"rollup": "^1.19.4",
 		"rollup-plugin-babel": "^4.3.3",
 		"rollup-plugin-node-resolve": "^5.2.0",
-		"typescript": "^3.6.4"
+		"typescript": "^3.7.2"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8853,11 +8853,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.6.4:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
-  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
-
 typescript@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"


### PR DESCRIPTION
## What is the purpose of this change?

Allows us to use some neat new syntax from Typescript, such as optional chaining

## What does this change?

Upgrades to Typescript v3.7.2
