### PR TITLE
Use unitless values for line-height

### DIFF
--- a/packages/foundations/src/theme.ts
+++ b/packages/foundations/src/theme.ts
@@ -8,7 +8,7 @@ const fonts = {
 		"GuardianTextSans, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif",
 }
 
-const lineHeights = ["1.15em", "1.35em", "1.45em"]
+const lineHeights = [1.15, 1.35, 1.45]
 
 const fontWeights = [300, 400, 500, 700]
 

--- a/packages/foundations/src/typography/index.ts
+++ b/packages/foundations/src/typography/index.ts
@@ -64,7 +64,7 @@ const fontMapping: { [cat in Category]: string } = {
 	textSans: fonts.bodySans,
 }
 
-const lineHeightMapping: { [lineHight in LineHeight]: string } = {
+const lineHeightMapping: { [lineHight in LineHeight]: number } = {
 	tight: lineHeights[0],
 	regular: lineHeights[1],
 	loose: lineHeights[2],


### PR DESCRIPTION
## What is the purpose of this change?

Using ems for line-height can lead to unexpected behaviour
when elements are nested under the element that declares the
line-height. To avoid this, [we use unitless values](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#Prefer_unitless_numbers_for_line-height_values), that
preserve the line-height for nested elements.


<!--
Give a brief summary of why you are proposing this change or new feature.
Please ensure you have read CONTRIBUTING.md
-->

## What does this change?


Use unitless values for line-height
<!--
Give an overview of the changes you have made
-->
