### PR TITLE
Add tokens for buttons

### DIFF
--- a/packages/button/themes.ts
+++ b/packages/button/themes.ts
@@ -13,18 +13,18 @@ export type ButtonTheme = {
 export const lightTheme: { button: ButtonTheme } = {
 	button: {
 		primary: {
-			backgroundColor: palette.brand.main,
-			color: palette.neutral[100],
-			hoverBackgroundColor: "#234B8A", //non-palette colour
+			color: palette.text.ctaPrimary,
+			backgroundColor: palette.background.ctaPrimary,
+			hoverBackgroundColor: palette.background.ctaPrimaryHover,
 		},
 		secondary: {
-			backgroundColor: palette.brand.faded,
-			color: palette.brand.main,
-			hoverBackgroundColor: "#96B0D9", //non-palette colour
+			color: palette.text.ctaSecondary,
+			backgroundColor: palette.background.ctaSecondary,
+			hoverBackgroundColor: palette.background.ctaSecondaryHover,
 		},
 		tertiary: {
-			backgroundColor: palette.neutral[100],
-			color: palette.brand.main,
+			color: palette.text.ctaSecondary,
+			backgroundColor: palette.background.primary,
 		},
 	},
 }
@@ -32,18 +32,18 @@ export const lightTheme: { button: ButtonTheme } = {
 export const darkTheme: { button: ButtonTheme } = {
 	button: {
 		primary: {
-			backgroundColor: palette.neutral[100],
-			color: palette.neutral[7],
-			hoverBackgroundColor: palette.neutral[93],
+			color: palette.text.mono.ctaPrimary,
+			backgroundColor: palette.background.mono.ctaPrimary,
+			hoverBackgroundColor: palette.background.mono.ctaPrimaryHover,
 		},
 		secondary: {
-			backgroundColor: palette.neutral[46],
-			color: palette.neutral[100],
-			hoverBackgroundColor: "#5C5C5C", //non-palette colour
+			color: palette.text.mono.ctaSecondary,
+			backgroundColor: palette.background.mono.ctaSecondary,
+			hoverBackgroundColor: palette.background.mono.ctaSecondaryHover,
 		},
 		tertiary: {
-			backgroundColor: palette.background.inverse,
-			color: palette.neutral[100],
+			color: palette.text.mono.ctaSecondary,
+			backgroundColor: palette.background.mono.primary,
 		},
 	},
 }
@@ -51,18 +51,18 @@ export const darkTheme: { button: ButtonTheme } = {
 export const blueTheme: { button: ButtonTheme } = {
 	button: {
 		primary: {
-			backgroundColor: palette.neutral[100],
-			color: palette.brand.main,
-			hoverBackgroundColor: palette.neutral[93],
+			color: palette.text.brand.ctaPrimary,
+			backgroundColor: palette.background.brand.ctaPrimary,
+			hoverBackgroundColor: palette.background.brand.ctaPrimaryHover,
 		},
 		secondary: {
-			backgroundColor: palette.brand.pastel,
-			color: palette.neutral[100],
-			hoverBackgroundColor: "#234B8A", // non-palette colour
+			color: palette.text.brand.ctaSecondary,
+			backgroundColor: palette.background.brand.ctaSecondary,
+			hoverBackgroundColor: palette.background.brand.ctaSecondaryHover,
 		},
 		tertiary: {
-			backgroundColor: palette.brand.main,
-			color: palette.neutral[100],
+			color: palette.text.brand.ctaSecondary,
+			backgroundColor: palette.background.brand.primary,
 		},
 	},
 }
@@ -70,18 +70,20 @@ export const blueTheme: { button: ButtonTheme } = {
 export const yellowTheme: { button: ButtonTheme } = {
 	button: {
 		primary: {
-			backgroundColor: palette.neutral[7],
-			color: palette.neutral[100],
-			hoverBackgroundColor: palette.neutral[20],
+			color: palette.text.brandYellow.ctaPrimary,
+			backgroundColor: palette.background.brandYellow.ctaPrimary,
+			hoverBackgroundColor:
+				palette.background.brandYellow.ctaPrimaryHover,
 		},
 		secondary: {
-			backgroundColor: palette.readerRevenue.dark,
-			color: palette.neutral[7],
-			hoverBackgroundColor: "#F2AE00", //non-palette colour
+			color: palette.text.brandYellow.ctaSecondary,
+			backgroundColor: palette.background.brandYellow.ctaSecondary,
+			hoverBackgroundColor:
+				palette.background.brandYellow.ctaSecondaryHover,
 		},
 		tertiary: {
-			backgroundColor: palette.readerRevenue.main,
-			color: palette.neutral[7],
+			color: palette.text.brandYellow.ctaSecondary,
+			backgroundColor: palette.background.brandYellow.primary,
 		},
 	},
 }
@@ -89,15 +91,17 @@ export const yellowTheme: { button: ButtonTheme } = {
 export const rrBlueTheme: { button: ButtonTheme } = {
 	button: {
 		primary: {
-			backgroundColor: palette.readerRevenue.main,
-			color: palette.brand.main,
-			hoverBackgroundColor: palette.readerRevenue.dark,
+			color: palette.text.readerRevenue.ctaPrimary,
+			backgroundColor: palette.background.readerRevenue.ctaPrimary,
+			hoverBackgroundColor:
+				palette.background.readerRevenue.ctaPrimaryHover,
 		},
 		secondary: {
-			backgroundColor: palette.brand.main,
-			color: palette.readerRevenue.main,
-			hoverBackgroundColor: palette.brand.dark,
-			borderColor: palette.readerRevenue.main,
+			color: palette.text.readerRevenue.ctaSecondary,
+			backgroundColor: palette.background.readerRevenue.ctaSecondary,
+			hoverBackgroundColor:
+				palette.background.readerRevenue.ctaSecondaryHover,
+			borderColor: palette.border.readerRevenue.ctaSecondary,
 		},
 		tertiary: {},
 	},
@@ -106,19 +110,19 @@ export const rrBlueTheme: { button: ButtonTheme } = {
 export const rrYellowTheme: { button: ButtonTheme } = {
 	button: {
 		primary: {
-			backgroundColor: palette.neutral[7],
-			color: palette.neutral[100],
-			hoverBackgroundColor: palette.neutral[20],
+			color: palette.text.readerRevenueYellow.ctaPrimary,
+			backgroundColor: palette.background.readerRevenueYellow.ctaPrimary,
+			hoverBackgroundColor:
+				palette.background.readerRevenueYellow.ctaPrimaryHover,
 		},
 		secondary: {
-			backgroundColor: palette.readerRevenue.main,
-			color: palette.neutral[7],
-			hoverBackgroundColor: palette.readerRevenue.dark,
-			borderColor: palette.neutral[7],
+			color: palette.text.readerRevenueYellow.ctaSecondary,
+			backgroundColor:
+				palette.background.readerRevenueYellow.ctaSecondary,
+			hoverBackgroundColor:
+				palette.background.readerRevenueYellow.ctaSecondaryHover,
+			borderColor: palette.border.readerRevenueYellow.ctaSecondary,
 		},
-		tertiary: {
-			backgroundColor: palette.neutral[100],
-			color: palette.brand.main,
-		},
+		tertiary: {},
 	},
 }

--- a/packages/foundations/src/palette.ts
+++ b/packages/foundations/src/palette.ts
@@ -1,94 +1,185 @@
 import { colors } from "./theme"
 
-const palette = {
+const brand = {
+	dark: colors.blues[5],
+	main: colors.blues[6],
+	bright: colors.blues[7],
+	pastel: colors.blues[8],
+	faded: colors.blues[9],
+}
+const brandYellow = {
+	dark: colors.yellows[0],
+	main: colors.yellows[1],
+}
+// TOO: remove in v0.9.0, prefer brandYellow
+const yellow = {
+	dark: colors.yellows[0],
+	main: colors.yellows[1],
+}
+const neutral = {
+	7: colors.grays[0],
+	20: colors.grays[1],
+	46: colors.grays[2],
+	60: colors.grays[3],
+	86: colors.grays[4],
+	93: colors.grays[5],
+	97: colors.grays[6],
+	100: colors.grays[7],
+	specialReport: colors.grays[8],
+	// TODO: remove in v0.9.0, prefer background.dark.primary
+	darkMode: colors.grays[9],
+}
+const error = {
+	main: colors.reds[1],
+	bright: colors.reds[2],
+}
+const success = {
+	main: colors.greens[1],
+}
+const news = {
+	dark: colors.reds[0],
+	main: colors.reds[1],
+	bright: colors.reds[2],
+	pastel: colors.reds[3],
+	faded: colors.reds[4],
+}
+const opinion = {
+	dark: colors.oranges[0],
+	main: colors.oranges[1],
+	bright: colors.oranges[2],
+	pastel: colors.oranges[3],
+	faded: colors.oranges[4],
+}
+const sport = {
+	dark: colors.blues[0],
+	main: colors.blues[1],
+	bright: colors.blues[2],
+	pastel: colors.blues[3],
+	faded: colors.blues[4],
+}
+const culture = {
+	dark: colors.browns[0],
+	main: colors.browns[1],
+	bright: colors.browns[2],
+	pastel: colors.browns[3],
+	faded: colors.browns[4],
+}
+const lifestyle = {
+	dark: colors.pinks[0],
+	main: colors.pinks[1],
+	bright: colors.pinks[2],
+	pastel: colors.pinks[3],
+	faded: colors.pinks[4],
+}
+const labs = {
+	dark: colors.greens[2],
+	main: colors.greens[3],
+}
+
+// functional colours
+const text = {
+	primary: neutral[7],
+	secondary: neutral[60],
+	ctaPrimary: neutral[100],
+	ctaSecondary: brand.main,
+	mono: {
+		primary: neutral[100],
+		secondary: neutral[60],
+		ctaPrimary: neutral[7],
+		ctaSecondary: neutral[100],
+	},
 	brand: {
-		dark: colors.blues[5],
-		main: colors.blues[6],
-		bright: colors.blues[7],
-		pastel: colors.blues[8],
-		faded: colors.blues[9],
+		primary: neutral[100],
+		secondary: neutral[60],
+		ctaPrimary: brand.main,
+		ctaSecondary: neutral[100],
 	},
-	// TODO: remove in v0.9.0, prefer readerRevenue
-	yellow: {
-		dark: colors.yellows[0],
-		main: colors.yellows[1],
-	},
-	neutral: {
-		7: colors.grays[0],
-		20: colors.grays[1],
-		46: colors.grays[2],
-		60: colors.grays[3],
-		86: colors.grays[4],
-		93: colors.grays[5],
-		97: colors.grays[6],
-		100: colors.grays[7],
-		specialReport: colors.grays[8],
-		// TODO: remove in v0.9.0, prefer themes.inverse.background
-		darkMode: colors.grays[9],
-	},
-	error: {
-		main: colors.reds[1],
-		bright: colors.reds[2],
-	},
-	success: {
-		main: colors.greens[1],
+	brandYellow: {
+		primary: neutral[7],
+		secondary: neutral[60],
+		ctaPrimary: neutral[100],
+		ctaSecondary: neutral[7],
 	},
 	readerRevenue: {
-		dark: colors.yellows[0],
-		main: colors.yellows[1],
+		primary: neutral[100],
+		secondary: neutral[60],
+		ctaPrimary: brand.main,
+		ctaSecondary: brandYellow.main,
 	},
-	text: {
-		main: colors.grays[0],
-		weak: colors.grays[3],
+	readerRevenueYellow: {
+		primary: neutral[7],
+		secondary: neutral[60],
+		ctaPrimary: neutral[100],
+		ctaSecondary: neutral[7],
 	},
-	background: {
-		inverse: colors.grays[10],
-		brand: colors.blues[6],
-		brandInverse: colors.yellows[1],
-		readerRevenue: colors.blues[6],
-		readerRevenueInverse: colors.yellows[1],
-		header: colors.blues[6],
-		footer: colors.blues[6],
+}
+const background = {
+	primary: neutral[100],
+	ctaPrimary: brand.main,
+	ctaPrimaryHover: "#234B8A",
+	ctaSecondary: brand.faded,
+	ctaSecondaryHover: "#96B0D9",
+	mono: {
+		primary: neutral[7],
+		ctaPrimary: neutral[100],
+		ctaPrimaryHover: neutral[93],
+		ctaSecondary: neutral[46],
+		ctaSecondaryHover: "#5C5C5C",
 	},
-	news: {
-		dark: colors.reds[0],
-		main: colors.reds[1],
-		bright: colors.reds[2],
-		pastel: colors.reds[3],
-		faded: colors.reds[4],
+	brand: {
+		primary: brand.main,
+		ctaPrimary: neutral[100],
+		ctaPrimaryHover: neutral[93],
+		ctaSecondary: brand.pastel,
+		ctaSecondaryHover: "#234B8A",
 	},
-	opinion: {
-		dark: colors.oranges[0],
-		main: colors.oranges[1],
-		bright: colors.oranges[2],
-		pastel: colors.oranges[3],
-		faded: colors.oranges[4],
+	brandYellow: {
+		primary: brandYellow.main,
+		ctaPrimary: neutral[7],
+		ctaPrimaryHover: neutral[20],
+		ctaSecondary: brandYellow.dark,
+		ctaSecondaryHover: "#F2AE00",
 	},
-	sport: {
-		dark: colors.blues[0],
-		main: colors.blues[1],
-		bright: colors.blues[2],
-		pastel: colors.blues[3],
-		faded: colors.blues[4],
+	readerRevenue: {
+		primary: brand.main,
+		ctaPrimary: brandYellow.main,
+		ctaPrimaryHover: brandYellow.dark,
+		ctaSecondary: brand.main,
+		ctaSecondaryHover: brand.dark,
 	},
-	culture: {
-		dark: colors.browns[0],
-		main: colors.browns[1],
-		bright: colors.browns[2],
-		pastel: colors.browns[3],
-		faded: colors.browns[4],
+	readerRevenueYellow: {
+		primary: brandYellow.main,
+		ctaPrimary: neutral[7],
+		ctaPrimaryHover: neutral[20],
+		ctaSecondary: brandYellow.main,
+		ctaSecondaryHover: brandYellow.dark,
 	},
-	lifestyle: {
-		dark: colors.pinks[0],
-		main: colors.pinks[1],
-		bright: colors.pinks[2],
-		pastel: colors.pinks[3],
-		faded: colors.pinks[4],
+}
+const border = {
+	readerRevenue: {
+		ctaSecondary: brandYellow.main,
 	},
-	labs: {
-		dark: colors.greens[2],
-		main: colors.greens[3],
+	readerRevenueYellow: {
+		ctaSecondary: neutral[7],
 	},
+}
+
+const palette = {
+	brand,
+	brandYellow,
+	yellow,
+	neutral,
+	error,
+	success,
+	news,
+	opinion,
+	sport,
+	culture,
+	lifestyle,
+	labs,
+	text,
+	background,
+	border,
 }
 
 export { palette }

--- a/packages/radio/themes.ts
+++ b/packages/radio/themes.ts
@@ -23,7 +23,7 @@ export const lightTheme: {
 		color: palette.neutral[60],
 		checkedColor: palette.brand.main,
 		textColor: palette.neutral[20],
-		supportingTextColor: palette.text.weak,
+		supportingTextColor: palette.text.secondary,
 		errorColor: palette.error.main,
 	},
 	...inlineErrorLightTheme,

--- a/packages/text-input/themes.ts
+++ b/packages/text-input/themes.ts
@@ -15,7 +15,7 @@ export const lightTheme: {
 	inlineError: InlineErrorTheme
 } = {
 	textInput: {
-		inputColor: palette.text.main,
+		inputColor: palette.text.primary,
 		textColor: palette.neutral[20],
 		backgroundColor: palette.neutral[100],
 	},


### PR DESCRIPTION
## What is the purpose of this change?

This is a first attempt at bringing function-specific design tokens into the design system. Exposing colours in this way should help to guide developers to using colours in their correct context. This should in turn help with colour contrast / accessibility, and make it easier to make design decisions. 

## What does this change?

Exposes colour tokens under `background`, `text` and `border`. 

We use these in the button theme, rather than pointing to palette colours directly.