### PR TITLE
Reinstate xlarge text sans size

### DIFF
--- a/packages/foundations/src/typography/index.ts
+++ b/packages/foundations/src/typography/index.ts
@@ -18,7 +18,7 @@ type HeadlineSizes =
 
 type BodySizes = "small" | "medium"
 
-type TextSansSizes = "xsmall" | "small" | "medium" | "large"
+type TextSansSizes = "xsmall" | "small" | "medium" | "large" | "xlarge"
 
 const fontSizesRem = fontSizes.map(fontSize => fontSize / 16)
 
@@ -48,6 +48,7 @@ const textSansSizes: { [key in TextSansSizes]: number } = {
 	small: fontSizesRem[1], //15px
 	medium: fontSizesRem[2], //17px
 	large: fontSizesRem[3], //20px
+	xlarge: fontSizesRem[4], //24px
 }
 
 const fontSizeMapping: { [cat in Category]: { [level in string]: number } } = {


### PR DESCRIPTION
## What is the purpose of this change?

There is currently no option for large headings in a sans font. Paid content uses the sans font throughout, including the headline. To make the headline look more like a headline, we should provide a large version of this font. 

## What does this change?

Adds a 24px `xlarge` size of text sans.

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

![Screenshot 2019-11-26 at 09 10 43](https://user-images.githubusercontent.com/5931528/69615370-a4571f80-102c-11ea-9608-f37a5249dc59.png)

