### PR TITLE
Disable focus halo on mousedown

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "source-components",
 	"version": "0.0.1",
 	"scripts": {
-		"storybook": "yarn watch:foundations & yarn watch:svgs & start-storybook",
+		"storybook": "yarn watch:foundations & yarn watch:svgs & yarn watch:utilities & start-storybook",
 		"lint:styles": "stylelint packages/**/styles.ts",
 		"lint:js": "eslint . --ext .ts,.tsx",
 		"lint": "yarn lint:js && yarn lint:styles",
@@ -15,12 +15,14 @@
 		"watch:foundations": "cd packages/foundations && yarn watch",
 		"watch:svgs": "cd packages/svgs && yarn watch",
 		"build:svgs": "cd packages/svgs && yarn build",
+		"build:utilities": "cd packages/utilities && yarn build",
+		"watch:utilities": "cd packages/utilities && yarn watch",
 		"build:button": "cd packages/button && yarn build",
 		"build:inline-error": "cd packages/inline-error && yarn build",
 		"build:radio": "cd packages/radio && yarn build",
 		"build:text-input": "cd packages/text-input && yarn build",
 		"build:checkbox": "cd packages/checkbox && yarn build",
-		"ci:build": "NODE_ENV=production yarn build:storybook && yarn build:foundations && yarn build:svgs && yarn build:button && yarn build:inline-error && yarn build:radio && yarn build:text-input && yarn build:checkbox"
+		"ci:build": "NODE_ENV=production yarn build:storybook && yarn build:foundations && yarn build:svgs && yarn build:utilities && yarn build:button && yarn build:inline-error && yarn build:radio && yarn build:text-input && yarn build:checkbox"
 	},
 	"private": true,
 	"workspaces": [

--- a/packages/foundations/src/accessibility/index.ts
+++ b/packages/foundations/src/accessibility/index.ts
@@ -9,11 +9,12 @@ const visuallyHidden = `
 	left: 0;
 `
 
-// TODO: migrate to using context-specific alias
 const focusHalo = `
 	outline: 0;
-	box-shadow: 0 0 0 5px ${palette.sport.bright};
-	z-index: 9;
+	html:not(.src-focus-disabled) & {
+		box-shadow: 0 0 0 5px ${palette.border.focusHalo};
+		z-index: 9;
+	}
 `
 
 export { visuallyHidden, focusHalo }

--- a/packages/foundations/src/palette.ts
+++ b/packages/foundations/src/palette.ts
@@ -164,6 +164,7 @@ const border = {
 	primary: neutral[60],
 	secondary: neutral[86],
 	error: error.main,
+	focusHalo: sport.bright,
 	radio: neutral[60],
 	radioHover: brand.main,
 	textInput: neutral[60],

--- a/packages/utilities/.babelrc.js
+++ b/packages/utilities/.babelrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+	presets: ["@babel/preset-env", "@babel/preset-typescript"]
+};

--- a/packages/utilities/.babelrc.js
+++ b/packages/utilities/.babelrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-	presets: ["@babel/preset-env", "@babel/preset-typescript"]
-};
+	presets: ["@babel/preset-env", "@babel/preset-typescript"],
+	plugins: ["@babel/plugin-proposal-class-properties"],
+}

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -1,0 +1,3 @@
+# Utilities
+
+## Focus manager

--- a/packages/utilities/index.ts
+++ b/packages/utilities/index.ts
@@ -1,0 +1,79 @@
+const TAB_KEY_CODE = 9
+
+/**
+ * Source: Blueprint https://blueprintjs.com/
+ * https://github.com/palantir/blueprint/blob/06a186c90758bbdca604ed6d7bf639c3d05b1fa0/packages/core/src/common/interactionMode.ts
+ * A nifty little class that maintains event handlers to add a class to the container element
+ * when entering "mouse mode" (on a `mousedown` event) and remove it when entering "keyboard mode"
+ * (on a `tab` key `keydown` event).
+ */
+export class InteractionModeEngine {
+	isRunning: boolean
+	container: Element
+	className: string
+
+	constructor(container: Element, className: string) {
+		this.container = container
+		this.className = className
+		this.isRunning = false
+	}
+
+	/** Returns whether the engine is currently running. */
+	isActive() {
+		return this.isRunning
+	}
+
+	/** Enable behavior which applies the given className when in mouse mode. */
+	start() {
+		this.container.addEventListener("mousedown", () =>
+			this.handleMouseDown(),
+		)
+		this.isRunning = true
+	}
+
+	/** Disable interaction mode behavior and remove className from container. */
+	stop() {
+		this.reset()
+		this.isRunning = false
+	}
+
+	reset() {
+		this.container.classList.remove(this.className)
+		this.container.removeEventListener("keydown", this
+			.handleKeyDown as EventListener)
+		this.container.removeEventListener("mousedown", () =>
+			this.handleMouseDown(),
+		)
+	}
+
+	handleKeyDown(e: KeyboardEvent) {
+		if (e.which === TAB_KEY_CODE) {
+			this.reset()
+			this.container.addEventListener("mousedown", () =>
+				this.handleMouseDown(),
+			)
+		}
+	}
+
+	handleMouseDown() {
+		console.log(this)
+		this.reset()
+		this.container.classList.add(this.className)
+		this.container.addEventListener("keydown", e =>
+			this.handleKeyDown(e as KeyboardEvent),
+		)
+	}
+}
+
+const FOCUS_DISABLED = "src-focus-disabled"
+
+const focusEngine = new InteractionModeEngine(
+	document.documentElement,
+	FOCUS_DISABLED,
+)
+
+export const FocusStyleManager = {
+	alwaysShowFocus: () => focusEngine.stop(),
+	isActive: () => focusEngine.isActive(),
+	onlyShowFocusOnTabs: () => focusEngine.start(),
+}

--- a/packages/utilities/index.ts
+++ b/packages/utilities/index.ts
@@ -6,62 +6,52 @@ const TAB_KEY_CODE = 9
  * A nifty little class that maintains event handlers to add a class to the container element
  * when entering "mouse mode" (on a `mousedown` event) and remove it when entering "keyboard mode"
  * (on a `tab` key `keydown` event).
+ * Requires @babel/plugin-proposal-class-properties
  */
 export class InteractionModeEngine {
-	isRunning: boolean
-	container: Element
-	className: string
+	private isRunning = false
 
-	constructor(container: Element, className: string) {
-		this.container = container
-		this.className = className
-		this.isRunning = false
-	}
+	// tslint:disable-next-line:no-constructor-vars
+	constructor(private container: Element, private className: string) {}
 
 	/** Returns whether the engine is currently running. */
-	isActive() {
+	public isActive() {
 		return this.isRunning
 	}
 
 	/** Enable behavior which applies the given className when in mouse mode. */
-	start() {
-		this.container.addEventListener("mousedown", () =>
-			this.handleMouseDown(),
-		)
+	public start() {
+		this.container.addEventListener("mousedown", this.handleMouseDown)
 		this.isRunning = true
 	}
 
 	/** Disable interaction mode behavior and remove className from container. */
-	stop() {
+	public stop() {
 		this.reset()
 		this.isRunning = false
 	}
 
-	reset() {
+	private reset() {
 		this.container.classList.remove(this.className)
-		this.container.removeEventListener("keydown", this
-			.handleKeyDown as EventListener)
-		this.container.removeEventListener("mousedown", () =>
-			this.handleMouseDown(),
-		)
+		this.container.removeEventListener("keydown", this.handleKeyDown as (
+			evt: Event,
+		) => void)
+		this.container.removeEventListener("mousedown", this.handleMouseDown)
 	}
 
-	handleKeyDown(e: KeyboardEvent) {
+	private handleKeyDown = (e: KeyboardEvent) => {
 		if (e.which === TAB_KEY_CODE) {
 			this.reset()
-			this.container.addEventListener("mousedown", () =>
-				this.handleMouseDown(),
-			)
+			this.container.addEventListener("mousedown", this.handleMouseDown)
 		}
 	}
 
-	handleMouseDown() {
-		console.log(this)
+	private handleMouseDown = () => {
 		this.reset()
 		this.container.classList.add(this.className)
-		this.container.addEventListener("keydown", e =>
-			this.handleKeyDown(e as KeyboardEvent),
-		)
+		this.container.addEventListener("keydown", this.handleKeyDown as (
+			evt: Event,
+		) => void)
 	}
 }
 

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -10,6 +10,7 @@
 		"prepublish": "yarn build"
 	},
 	"devDependencies": {
+		"@babel/plugin-proposal-class-properties": "^7.7.4",
 		"@babel/preset-env": "^7.5.5",
 		"@babel/preset-typescript": "^7.3.3",
 		"rollup": "^1.19.4",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@guardian/src-utilities",
+	"version": "0.2.0",
+	"main": "dist/utilities.js",
+	"module": "dist/utilities.esm.js",
+	"scripts": {
+		"build": "yarn clean && rollup --config",
+		"clean": "rm -rf dist",
+		"prepublish": "yarn build"
+	},
+	"devDependencies": {
+		"@babel/preset-env": "^7.5.5",
+		"@babel/preset-typescript": "^7.3.3",
+		"rollup": "^1.19.4",
+		"rollup-plugin-babel": "^4.3.3",
+		"rollup-plugin-node-resolve": "^5.2.0",
+		"typescript": "^3.7.2"
+	}
+}

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -5,6 +5,7 @@
 	"module": "dist/utilities.esm.js",
 	"scripts": {
 		"build": "yarn clean && rollup --config",
+		"watch": "rollup --config --watch",
 		"clean": "rm -rf dist",
 		"prepublish": "yarn build"
 	},

--- a/packages/utilities/rollup.config.js
+++ b/packages/utilities/rollup.config.js
@@ -1,0 +1,20 @@
+import babel from "rollup-plugin-babel"
+import resolve from "rollup-plugin-node-resolve"
+import commonjs from "rollup-plugin-commonjs"
+
+const extensions = [".ts", ".tsx"]
+
+module.exports = {
+	input: "index.ts",
+	output: [
+		{
+			file: "dist/utilities.js",
+			format: "cjs",
+		},
+		{
+			file: "dist/utilities.esm.js",
+			format: "esm",
+		},
+	],
+	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
 			],
 			"@guardian/src-inline-error": ["inline-error"],
 			"@guardian/src-helpers": ["helpers"],
-			"@guardian/src-svgs": ["svgs"]
+			"@guardian/src-svgs": ["svgs"],
+			"@guardian/src-utilities": ["utilities"]
 		},
 		"outDir": "dist",
 		"module": "commonjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,6 +67,16 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+"@babel/generator@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.7.4.tgz#db651e2840ca9aa66f327dcec1dc5f5fa9611369"
+  integrity sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==
+  dependencies:
+    "@babel/types" "^7.7.4"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
 "@babel/helper-annotate-as-pure@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
@@ -111,6 +121,18 @@
     "@babel/helper-replace-supers" "^7.5.5"
     "@babel/helper-split-export-declaration" "^7.4.4"
 
+"@babel/helper-create-class-features-plugin@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.7.4.tgz#fce60939fd50618610942320a8d951b3b639da2d"
+  integrity sha512-l+OnKACG4uiDHQ/aJT8dwpR+LhCJALxL0mJ6nzjB25e5IPwqV1VOsY7ah6UB1DG+VOXAIMtuC54rFJGiHkxjgA==
+  dependencies:
+    "@babel/helper-function-name" "^7.7.4"
+    "@babel/helper-member-expression-to-functions" "^7.7.4"
+    "@babel/helper-optimise-call-expression" "^7.7.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.7.4"
+    "@babel/helper-split-export-declaration" "^7.7.4"
+
 "@babel/helper-define-map@^7.4.0", "@babel/helper-define-map@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz#3dec32c2046f37e09b28c93eb0b103fd2a25d369"
@@ -137,12 +159,28 @@
     "@babel/template" "^7.1.0"
     "@babel/types" "^7.0.0"
 
+"@babel/helper-function-name@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz#ab6e041e7135d436d8f0a3eca15de5b67a341a2e"
+  integrity sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.7.4"
+    "@babel/template" "^7.7.4"
+    "@babel/types" "^7.7.4"
+
 "@babel/helper-get-function-arity@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
   integrity sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
   dependencies:
     "@babel/types" "^7.0.0"
+
+"@babel/helper-get-function-arity@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz#cb46348d2f8808e632f0ab048172130e636005f0"
+  integrity sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==
+  dependencies:
+    "@babel/types" "^7.7.4"
 
 "@babel/helper-hoist-variables@^7.4.4":
   version "7.4.4"
@@ -157,6 +195,13 @@
   integrity sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==
   dependencies:
     "@babel/types" "^7.5.5"
+
+"@babel/helper-member-expression-to-functions@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz#356438e2569df7321a8326644d4b790d2122cb74"
+  integrity sha512-9KcA1X2E3OjXl/ykfMMInBK+uVdfIVakVe7W7Lg3wfXUNyS3Q1HWLFRwZIjhqiCGbslummPDnmb7vIekS0C1vw==
+  dependencies:
+    "@babel/types" "^7.7.4"
 
 "@babel/helper-module-imports@^7.0.0":
   version "7.0.0"
@@ -183,6 +228,13 @@
   integrity sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==
   dependencies:
     "@babel/types" "^7.0.0"
+
+"@babel/helper-optimise-call-expression@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz#034af31370d2995242aa4df402c3b7794b2dcdf2"
+  integrity sha512-VB7gWZ2fDkSuqW6b1AKXkJWO5NyNI3bFL/kK79/30moK57blr6NbH8xcl2XcKCwOmJosftWunZqfO84IGq3ZZg==
+  dependencies:
+    "@babel/types" "^7.7.4"
 
 "@babel/helper-plugin-utils@^7.0.0":
   version "7.0.0"
@@ -217,6 +269,16 @@
     "@babel/traverse" "^7.5.5"
     "@babel/types" "^7.5.5"
 
+"@babel/helper-replace-supers@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz#3c881a6a6a7571275a72d82e6107126ec9e2cdd2"
+  integrity sha512-pP0tfgg9hsZWo5ZboYGuBn/bbYT/hdLPVSS4NMmiRJdwWhP0IznPwN9AE1JwyGsjSPLC364I0Qh5p+EPkGPNpg==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.7.4"
+    "@babel/helper-optimise-call-expression" "^7.7.4"
+    "@babel/traverse" "^7.7.4"
+    "@babel/types" "^7.7.4"
+
 "@babel/helper-simple-access@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz#65eeb954c8c245beaa4e859da6188f39d71e585c"
@@ -231,6 +293,13 @@
   integrity sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
   dependencies:
     "@babel/types" "^7.4.4"
+
+"@babel/helper-split-export-declaration@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz#57292af60443c4a3622cf74040ddc28e68336fd8"
+  integrity sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==
+  dependencies:
+    "@babel/types" "^7.7.4"
 
 "@babel/helper-wrap-function@^7.1.0":
   version "7.2.0"
@@ -265,6 +334,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.5.5.tgz#02f077ac8817d3df4a832ef59de67565e71cca4b"
   integrity sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==
 
+"@babel/parser@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.4.tgz#75ab2d7110c2cf2fa949959afb05fa346d2231bb"
+  integrity sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==
+
 "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz#b289b306669dce4ad20b0252889a15768c9d417e"
@@ -288,6 +362,14 @@
   integrity sha512-AF79FsnWFxjlaosgdi421vmYG6/jg79bVD0dpD44QdgobzHKuLZ6S3vl8la9qIeSwGi8i1fS0O1mfuDAAdo1/A==
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.5.5"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-proposal-class-properties@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.7.4.tgz#2f964f0cb18b948450362742e33e15211e77c2ba"
+  integrity sha512-EcuXeV4Hv1X3+Q1TsuOmyyxeTRiSqurGJ26+I/FW1WbymmRRapVORm6x1Zl3iDIHyRxEs+VXWp6qnlcfcJSbbw==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.7.4"
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-proposal-decorators@7.4.0":
@@ -935,6 +1017,15 @@
     "@babel/parser" "^7.4.4"
     "@babel/types" "^7.4.4"
 
+"@babel/template@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.7.4.tgz#428a7d9eecffe27deac0a98e23bf8e3675d2a77b"
+  integrity sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.7.4"
+    "@babel/types" "^7.7.4"
+
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.5.5.tgz#f664f8f368ed32988cd648da9f72d5ca70f165bb"
@@ -950,10 +1041,34 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.7.4.tgz#9c1e7c60fb679fe4fcfaa42500833333c2058558"
+  integrity sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.7.4"
+    "@babel/helper-function-name" "^7.7.4"
+    "@babel/helper-split-export-declaration" "^7.7.4"
+    "@babel/parser" "^7.7.4"
+    "@babel/types" "^7.7.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.5.5.tgz#97b9f728e182785909aa4ab56264f090a028d18a"
   integrity sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.7.4.tgz#516570d539e44ddf308c07569c258ff94fde9193"
+  integrity sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"


### PR DESCRIPTION
## What is the purpose of this change?

The focus halo ring offers most benefit to keyboard users, who use it to track the element that is currently focused.

The design is deliberately quite intense and distracting. Since mouse users do not get as much benefit, we should disable the focus halo on mousedown.

## What does this change?

Adds a utilities package, which exposes a class that can be used to disable the intense focus styling for mouse users.
