### PR TITLE
Use focus manager in storybook

### DIFF
--- a/.storybook/config.tsx
+++ b/.storybook/config.tsx
@@ -1,4 +1,7 @@
-import { configure, addParameters } from "@storybook/react"
+import React from "react"
+import { configure, addParameters, addDecorator } from "@storybook/react"
+import { useEffect } from "@storybook/addons"
+import { FocusStyleManager } from "@guardian/src-utilities"
 
 const storiesOnly = process.env.NODE_ENV === "production"
 
@@ -15,3 +18,13 @@ addParameters({
 })
 
 configure(require.context("../packages", true, /stories\.tsx$/), module)
+
+const FocusManagerDecorator = storyFn => {
+	useEffect(() => {
+		FocusStyleManager.onlyShowFocusOnTabs()
+	})
+
+	return <div>{storyFn()}</div>
+}
+
+addDecorator(FocusManagerDecorator)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"build:radio": "cd packages/radio && yarn build",
 		"build:text-input": "cd packages/text-input && yarn build",
 		"build:checkbox": "cd packages/checkbox && yarn build",
-		"ci:build": "NODE_ENV=production yarn build:storybook && yarn build:foundations && yarn build:svgs && yarn build:utilities && yarn build:button && yarn build:inline-error && yarn build:radio && yarn build:text-input && yarn build:checkbox"
+		"ci:build": "NODE_ENV=production yarn build:foundations && yarn build:svgs && yarn build:utilities && yarn build:button && yarn build:inline-error && yarn build:radio && yarn build:text-input && yarn build:checkbox && yarn build:storybook"
 	},
 	"private": true,
 	"workspaces": [


### PR DESCRIPTION
## What is the purpose of this change?

It's not desirable to always show the focus halo on click of every component. We should hide it using the focus manager introduced in #105 

## What does this change?

Uses a decorator to instruct the focus manager to `onlyShowFocusOnTabs`
