### PR TITLE
center align button contents

### DIFF
--- a/packages/button/styles.ts
+++ b/packages/button/styles.ts
@@ -7,6 +7,7 @@ import { focusHalo } from "@guardian/src-foundations/accessibility"
 export const button = css`
 	display: inline-flex;
 	justify-content: space-between;
+	align-items: center;
 	${textSans.medium({ fontWeight: "bold" })};
 	box-sizing: border-box;
 	border: none;


### PR DESCRIPTION
## What is the purpose of this change?

There's a small bug in Firefox in which button contents are top-aligned instead of centre-aligned

<!--
Give a brief summary of why you are proposing this change or new feature.
Please ensure you have read CONTRIBUTING.md
-->

## What does this change?

Explicitly centre-aligns content

## Design

### Screenshots

**Before**

![Screenshot 2019-12-04 at 14 58 12](https://user-images.githubusercontent.com/5931528/70153350-b5480680-16a6-11ea-8541-c0128d1a029e.png)

**After**

![Screenshot 2019-12-04 at 14 58 18](https://user-images.githubusercontent.com/5931528/70153353-b5e09d00-16a6-11ea-85e0-574d85ac1aef.png)

