### PR TITLE
Emit types in build of SVG package

### DIFF
--- a/packages/svgs/.gitignore
+++ b/packages/svgs/.gitignore
@@ -1,0 +1,2 @@
+# Ignore built files
+*.d.ts

--- a/packages/svgs/package.json
+++ b/packages/svgs/package.json
@@ -4,9 +4,9 @@
 	"main": "dist/index.js",
 	"module": "dist/index.esm.js",
 	"scripts": {
-		"build": "rollup --config",
+		"build": "yarn clean && tsc && rollup --config",
 		"watch": "rollup --config --watch",
-		"clean": "rm -rf dist",
+		"clean": "rm -rf dist *.d.ts",
 		"prepublish": "yarn build"
 	},
 	"devDependencies": {
@@ -15,7 +15,8 @@
 		"@babel/preset-react": "^7.0.0",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
-		"rollup-plugin-node-resolve": "^5.2.0"
+		"rollup-plugin-node-resolve": "^5.2.0",
+		"typescript": "^3.7.2"
 	},
 	"files": [
 		"alert.tsx",
@@ -26,7 +27,8 @@
 		"checkmark.tsx",
 		"close.tsx",
 		"minus.tsx",
-		"plus.tsx"
+		"plus.tsx",
+		"*.d.ts"
 	],
 	"peerDependencies": {
 		"react": "^16.8.6"

--- a/packages/svgs/tsconfig.json
+++ b/packages/svgs/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"compilerOptions": {
+		"outDir": ".",
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		"jsx": "preserve",
+		"esModuleInterop": true
+	},
+	"exclude": ["node_modules"]
+}


### PR DESCRIPTION
## What is the purpose of this change?

Types are not currently emitted as part of the SVG build process. This causes projects that consume the library to implicitly import the SVGs as `any`, causing compiler errors.

## What does this change?

Emits types for SVGs and publishes them to NPM
