### PR TITLE
Link buttons

### DIFF
--- a/packages/button/index.tsx
+++ b/packages/button/index.tsx
@@ -94,13 +94,59 @@ const Button = ({
 		</button>
 	)
 }
-const defaultProps = {
+
+const LinkButton = ({
+	priority,
+	size,
+	icon: iconSvg,
+	iconSide,
+	children,
+	...props
+}: {
+	priority: Priority
+	size: Size
+	icon?: ReactElement
+	iconSide: IconSide
+	href: string
+	children?: ReactNode
+}) => {
+	const buttonContents = [children]
+
+	if (iconSvg) {
+		buttonContents.push(React.cloneElement(iconSvg, { key: "svg" }))
+	}
+
+	return (
+		<a
+			css={theme => [
+				button,
+				sizes[size],
+				priorities[priority](theme.button && theme),
+				iconSvg ? iconSizes[size] : "",
+				iconSvg && children ? iconSides[iconSide] : "",
+				!children ? iconOnlySizes[size] : "",
+			]}
+			{...props}
+		>
+			{buttonContents}
+		</a>
+	)
+}
+
+const defaultButtonProps = {
 	type: "button",
 	priority: "primary",
 	size: "default",
 	iconSide: "left",
 }
 
-Button.defaultProps = { ...defaultProps }
+const defaultLinkButtonProps = {
+	priority: "primary",
+	size: "default",
+	iconSide: "right",
+}
 
-export { Button }
+Button.defaultProps = { ...defaultButtonProps }
+LinkButton.defaultProps = { ...defaultLinkButtonProps }
+
+export { Button, LinkButton }

--- a/packages/button/stories.tsx
+++ b/packages/button/stories.tsx
@@ -12,6 +12,7 @@ import {
 import { size } from "@guardian/src-foundations"
 import {
 	Button,
+	LinkButton,
 	buttonLight,
 	buttonBrandYellow,
 	buttonBrand,
@@ -32,7 +33,7 @@ const sizeButtons = [
 ]
 const textIconButtons = [
 	<Button icon={<SvgCheckmark />}>Left aligned</Button>,
-	<Button iconSide="right" icon={<SvgArrowRightStraight />}>
+	<Button iconSide="right" icon={<SvgCheckmark />}>
 		Right aligned
 	</Button>,
 ]
@@ -43,6 +44,20 @@ const iconButtons = [
 		size="small"
 		aria-label="Dismiss the subscribe banner"
 	/>,
+]
+const linkButtons = [
+	<LinkButton href="#">Primary</LinkButton>,
+	<LinkButton href="#" priority="secondary">
+		Secondary
+	</LinkButton>,
+	<LinkButton href="#" priority="tertiary">
+		Tertiary
+	</LinkButton>,
+]
+const textIconLinkButtons = [
+	<LinkButton href="#" icon={<SvgArrowRightStraight />}>
+		Right aligned
+	</LinkButton>,
 ]
 /* eslint-enable react/jsx-key */
 
@@ -214,3 +229,21 @@ export const iconOnly = () => (
 iconOnly.story = {
 	name: "icon only",
 }
+
+export const priorityLinkButtons = () => (
+	<div css={flexStart}>
+		{linkButtons.map((button, index) => (
+			<div key={index}>{button}</div>
+		))}
+	</div>
+)
+priorityLinkButtons.story = { name: "priority link buttons" }
+
+export const textAndIconLinkButtons = () => (
+	<div css={flexStart}>
+		{textIconLinkButtons.map((button, index) => (
+			<div key={index}>{button}</div>
+		))}
+	</div>
+)
+textAndIconLinkButtons.story = { name: "text and icon link buttons" }

--- a/packages/button/styles.ts
+++ b/packages/button/styles.ts
@@ -14,6 +14,7 @@ export const button = css`
 	background: transparent;
 	cursor: pointer;
 	transition: ${transitions.medium};
+	text-decoration: none;
 
 	&:focus {
 		${focusHalo};


### PR DESCRIPTION
## What is the purpose of this change?

Sometimes we want buttons that behave like links (i.e. they are navigational, rather than trigger an action). From a designer's perspective and a user's perspective, they look like buttons, but functionally they are represented by different HTML elements.

## What does this change?

Adds a `LinkButton` component into the `src-button` package, that takes the same styling as a button but ultimately renders an `<a>` element instead of a `<button>`.

## Design

### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
