### PR TITLE
Add Grid component

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+*.d.ts

--- a/packages/grid/.babelrc.js
+++ b/packages/grid/.babelrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+	presets: [
+		"@babel/preset-env",
+		"@babel/preset-react",
+		"@babel/preset-typescript",
+		"@emotion/babel-preset-css-prop",
+	],
+}

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -48,17 +48,20 @@ const ArticleAlt = () => (
 The number of columns a grid item should span at the specified breakpoints.
 
 Adopt a mobile-first mindset when using this prop. If a span for a narrow breakpoint is specified (e.g. `mobile`),
-wider breakpoints will also use this span value unless they are specifically overridden.
+wider breakpoints will also use this span value unless it is specifically overridden.
 
 The narrowest specified breakpoint will be the first breakpoint at which the grid item is visible. At narrower
 breakpoints, the grid item will have `display: none` applied to it.
 
 ### `startingPos`
 
-**`number`**
+**`{ mobile?: number, tablet?: number, desktop?: number, wide?: number }`**
 
-The column number at which the grid item should begin. If omitted, the grid item will begin at the next available
-column.
+The column number at which the grid item should begin at the specified breakpoints. If this props is omitted, the grid
+item will begin at the next available column.
+
+Adopt a mobile-first mindset when using this prop. If a starting position for a narrow breakpoint is specified (e.g. `mobile`),
+wider breakpoints will also use this starting position value unless it is specifically overridden.
 
 ### `borderRight`
 

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -10,6 +10,8 @@ $ yarn add @guardian/src-grid @guardian/src-foundations
 
 ## Use
 
+**Note:** this component does not currently have support for Internet Explorer
+
 ```js
 import { Grid, GridItem, gridItem } from "@guardian/src-grid"
 

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -1,0 +1,67 @@
+# Grid
+
+📣 For more context and visual guides relating grid usage on the [Source Design System website](https://zeroheight.com/2a1e5182b/p/41be19)
+
+## Install
+
+```sh
+$ yarn add @guardian/src-grid @guardian/src-foundations
+```
+
+## Use
+
+```js
+import { Grid, GridItem, gridItem } from "@guardian/src-grid"
+
+const Article = () => (
+    <Grid>
+        <GridItem span={{ tablet: 3, desktop: 4 }}>
+            <Sidebar />
+        </GridItem>
+        <GridItem span={{ tablet: 9, desktop: 8 }}>
+            <Main />
+        </GridItem>
+    </Grid>
+)
+
+const sidebar = css`
+    ${gridItem({ span: { tablet: 3, desktop: 4 } })}
+`
+const main = css`
+    ${gridItem({ span: { tablet: 9, desktop: 8 } })}
+`
+
+const ArticleAlt = () => (
+    <Grid>
+        <div css={sidebar}></div>
+        <div css={main}></div>
+    </Grid>
+)
+```
+
+## `GridItem` Props
+
+### `span`
+
+**`{ mobile?: number, tablet?: number, desktop?: number, wide?: number }`**
+
+The number of columns a grid item should span at the specified breakpoints.
+
+Adopt a mobile-first mindset when using this prop. If a span for a narrow breakpoint is specified (e.g. `mobile`),
+wider breakpoints will also use this span value unless they are specifically overridden.
+
+The narrowest specified breakpoint will be the first breakpoint at which the grid item is visible. At narrower
+breakpoints, the grid item will have `display: none` applied to it.
+
+### `startingPos`
+
+**`number`**
+
+The column number at which the grid item should begin. If omitted, the grid item will begin at the next available
+column.
+
+### `borderRight`
+
+**`boolean`**_= false_
+
+Whether a border should appear to the right of the grid item.

--- a/packages/grid/index.tsx
+++ b/packages/grid/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { gridContainer, gridItem, Spans } from "./styles"
+import { gridContainer, gridItem, Spans, StartingPos } from "./styles"
 
 const Grid = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
 	<div css={gridContainer}>{children}</div>
@@ -12,7 +12,7 @@ const GridItem = ({
 	children,
 }: {
 	span: Spans
-	startingPos?: number
+	startingPos?: StartingPos
 	borderRight?: boolean
 	children: JSX.Element | JSX.Element[]
 }) => {

--- a/packages/grid/index.tsx
+++ b/packages/grid/index.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import { gridContainer, gridItem, Spans } from "./styles"
+
+const Grid = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+	<div css={gridContainer}>{children}</div>
+)
+
+const GridItem = ({
+	span,
+	startingPos,
+	borderRight,
+	children,
+}: {
+	span: Spans
+	startingPos?: number
+	borderRight?: boolean
+	children: JSX.Element | JSX.Element[]
+}) => {
+	return (
+		<div css={gridItem({ span, startingPos, borderRight })}>{children}</div>
+	)
+}
+
+export { Grid, GridItem, gridItem }

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,0 +1,33 @@
+{
+	"name": "@guardian/src-grid",
+	"version": "0.0.1",
+	"main": "dist/grid.js",
+	"module": "dist/grid.esm.js",
+	"scripts": {
+		"build": "yarn clean && rollup --config",
+		"clean": "rm -rf dist",
+		"prepublish": "yarn build"
+	},
+	"devDependencies": {
+		"@babel/core": "^7.5.5",
+		"@babel/preset-env": "^7.5.5",
+		"@babel/preset-react": "^7.0.0",
+		"@babel/preset-typescript": "^7.3.3",
+		"@emotion/babel-preset-css-prop": "^10.0.14",
+		"@guardian/src-foundations": "^0.8.0",
+		"@guardian/src-helpers": "^0.0.1",
+		"rollup": "^1.17.0",
+		"rollup-plugin-babel": "^4.3.3",
+		"rollup-plugin-commonjs": "^10.0.2",
+		"rollup-plugin-node-resolve": "^5.2.0"
+	},
+	"files": [
+		"index.tsx",
+		"styles.ts"
+	],
+	"peerDependencies": {
+		"@emotion/core": "^10.0.14",
+		"@guardian/src-foundations": "^0.9.0",
+		"react": "^16.8.6"
+	}
+}

--- a/packages/grid/rollup.config.js
+++ b/packages/grid/rollup.config.js
@@ -1,0 +1,29 @@
+import babel from "rollup-plugin-babel"
+import resolve from "rollup-plugin-node-resolve"
+import commonjs from "rollup-plugin-commonjs"
+
+const extensions = [".ts", ".tsx"]
+
+module.exports = {
+	input: "index.tsx",
+	output: [
+		{
+			file: "dist/grid.js",
+			format: "cjs",
+			sourceMap: true,
+		},
+		{
+			file: "dist/grid.esm.js",
+			format: "esm",
+			sourceMap: true,
+		},
+	],
+	external: [
+		"react",
+		"@emotion/core",
+		"@emotion/css",
+		"@guardian/src-foundations",
+		"@guardian/src-foundations/mq",
+	],
+	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
+}

--- a/packages/grid/styles.ts
+++ b/packages/grid/styles.ts
@@ -1,0 +1,120 @@
+import { css } from "@emotion/core"
+import {
+	Breakpoint,
+	space,
+	breakpoints,
+	palette,
+} from "@guardian/src-foundations"
+import { from } from "@guardian/src-foundations/mq"
+
+type GridBreakpoints = Extract<Breakpoint, "tablet" | "desktop" | "wide">
+
+type GridColumns = {
+	[key in GridBreakpoints]: number
+}
+
+type ContainerWidths = {
+	[key in GridBreakpoints]: number
+}
+
+const gridColumns: GridColumns = {
+	tablet: 12,
+	desktop: 12,
+	wide: 16,
+}
+
+const containerWidths: ContainerWidths = {
+	tablet: breakpoints.tablet,
+	desktop: breakpoints.desktop,
+	wide: breakpoints.wide,
+}
+
+export const gridContainer = css`
+	@supports (display: grid) {
+		display: grid;
+	}
+
+	padding: 0 ${space[3]}px;
+	grid-auto-columns: max-content;
+	column-gap: ${space[5]}px;
+
+	width: 100%;
+	grid-template-columns: repeat(4, 1fr);
+
+	${from.tablet} {
+		padding: 0 ${space[5]}px;
+		width: ${containerWidths.tablet}px;
+		grid-template-columns: repeat(${gridColumns.tablet}, 1fr);
+	}
+
+	${from.desktop} {
+		width: ${containerWidths.desktop}px;
+		grid-template-columns: repeat(${gridColumns.desktop}, 1fr);
+	}
+
+	${from.wide} {
+		width: ${containerWidths.wide}px;
+		grid-template-columns: repeat(${gridColumns.wide}, 1fr);
+	}
+`
+const borderRightStyle = css`
+	border-right: 1px solid ${palette.border.secondary};
+	padding-right: ${space[5] / 2}px;
+	margin-right: ${-space[5] / 2}px;
+`
+
+const gridItemBreakpoints: readonly Extract<
+	Breakpoint,
+	"mobile" | "tablet" | "desktop" | "wide"
+>[] = ["mobile", "tablet", "desktop", "wide"] as const
+type GridItemBreakpoints = typeof gridItemBreakpoints[number]
+
+export type Spans = {
+	[key in GridItemBreakpoints]?: number
+}
+
+const gridItemSpans = (spans: Spans) => {
+	let minimumBreakpointSet = false
+	let style = ""
+
+	for (let i = 0; i < gridItemBreakpoints.length; i += 1) {
+		const breakpoint = gridItemBreakpoints[i]
+
+		if (spans[breakpoint]) {
+			style = `${style}
+				${from[breakpoint]} {
+					display: initial;
+					grid-column-end: span ${spans[breakpoint]};
+				}
+			`
+
+			if (!minimumBreakpointSet) {
+				minimumBreakpointSet = true
+			}
+		} else {
+			if (!minimumBreakpointSet) {
+				style = `${style}
+				${from[breakpoint]} {
+					display: none;
+				}
+			`
+			}
+		}
+	}
+
+	return style
+}
+
+export const gridItem = ({
+	span,
+	startingPos,
+	borderRight = false,
+}: {
+	span: Spans
+	startingPos?: number
+	borderRight?: boolean
+}) => css`
+	${gridItemSpans(span)}
+	${startingPos ? `grid-column-start: ${startingPos};` : ""}
+	${borderRight ? borderRightStyle : ""}
+`

--- a/packages/grid/styles.ts
+++ b/packages/grid/styles.ts
@@ -7,10 +7,11 @@ import {
 } from "@guardian/src-foundations"
 import { from } from "@guardian/src-foundations/mq"
 
-type GridBreakpoints = Extract<
+const gridBreakpoints: readonly Extract<
 	Breakpoint,
 	"tablet" | "desktop" | "leftCol" | "wide"
->
+>[] = ["tablet", "desktop", "leftCol", "wide"] as const
+type GridBreakpoints = typeof gridBreakpoints[number]
 
 type GridColumns = {
 	[key in GridBreakpoints]: number
@@ -48,24 +49,16 @@ export const gridContainer = css`
 
 	${from.tablet} {
 		padding: 0 ${space[5]}px;
-		width: ${containerWidths.tablet}px;
-		grid-template-columns: repeat(${gridColumns.tablet}, 1fr);
 	}
 
-	${from.desktop} {
-		width: ${containerWidths.desktop}px;
-		grid-template-columns: repeat(${gridColumns.desktop}, 1fr);
-	}
-
-	${from.leftCol} {
-		width: ${containerWidths.leftCol}px;
-		grid-template-columns: repeat(${gridColumns.leftCol}, 1fr);
-	}
-
-	${from.wide} {
-		width: ${containerWidths.wide}px;
-		grid-template-columns: repeat(${gridColumns.wide}, 1fr);
-	}
+	${gridBreakpoints.reduce((acc, breakpoint) => {
+		return `${acc}
+			${from[breakpoint]} {
+				width: ${containerWidths[breakpoint]}px;
+				grid-template-columns: repeat(${gridColumns[breakpoint]}, 1fr);
+			}
+		`
+	}, "")}
 `
 const borderRightStyle = css`
 	border-right: 1px solid ${palette.border.secondary};

--- a/packages/grid/styles.ts
+++ b/packages/grid/styles.ts
@@ -90,7 +90,7 @@ const gridItemSpans = (spans: Spans) => {
 		if (spans[breakpoint]) {
 			style = `${style}
 				${from[breakpoint]} {
-					display: initial;
+					display: block;
 					grid-column-end: span ${spans[breakpoint]};
 				}
 			`

--- a/packages/grid/styles.ts
+++ b/packages/grid/styles.ts
@@ -7,7 +7,10 @@ import {
 } from "@guardian/src-foundations"
 import { from } from "@guardian/src-foundations/mq"
 
-type GridBreakpoints = Extract<Breakpoint, "tablet" | "desktop" | "wide">
+type GridBreakpoints = Extract<
+	Breakpoint,
+	"tablet" | "desktop" | "leftCol" | "wide"
+>
 
 type GridColumns = {
 	[key in GridBreakpoints]: number
@@ -20,12 +23,14 @@ type ContainerWidths = {
 const gridColumns: GridColumns = {
 	tablet: 12,
 	desktop: 12,
+	leftCol: 14,
 	wide: 16,
 }
 
 const containerWidths: ContainerWidths = {
 	tablet: breakpoints.tablet,
 	desktop: breakpoints.desktop,
+	leftCol: breakpoints.leftCol,
 	wide: breakpoints.wide,
 }
 
@@ -52,6 +57,11 @@ export const gridContainer = css`
 		grid-template-columns: repeat(${gridColumns.desktop}, 1fr);
 	}
 
+	${from.leftCol} {
+		width: ${containerWidths.leftCol}px;
+		grid-template-columns: repeat(${gridColumns.leftCol}, 1fr);
+	}
+
 	${from.wide} {
 		width: ${containerWidths.wide}px;
 		grid-template-columns: repeat(${gridColumns.wide}, 1fr);
@@ -65,11 +75,15 @@ const borderRightStyle = css`
 
 const gridItemBreakpoints: readonly Extract<
 	Breakpoint,
-	"mobile" | "tablet" | "desktop" | "wide"
->[] = ["mobile", "tablet", "desktop", "wide"] as const
+	"mobile" | "tablet" | "desktop" | "leftCol" | "wide"
+>[] = ["mobile", "tablet", "desktop", "leftCol", "wide"] as const
 type GridItemBreakpoints = typeof gridItemBreakpoints[number]
 
 export type Spans = {
+	[key in GridItemBreakpoints]?: number
+}
+
+export type StartingPos = {
 	[key in GridItemBreakpoints]?: number
 }
 
@@ -105,16 +119,30 @@ const gridItemSpans = (spans: Spans) => {
 	return style
 }
 
+const gridItemStartingPos = (startingPos: StartingPos) => {
+	return gridItemBreakpoints.reduce((acc, breakpoint) => {
+		if (startingPos[breakpoint]) {
+			return `${acc}
+				${from[breakpoint]} {
+					grid-column-start: ${startingPos[breakpoint]};
+				}
+			`
+		}
+
+		return acc
+	}, "")
+}
+
 export const gridItem = ({
 	span,
 	startingPos,
 	borderRight = false,
 }: {
 	span: Spans
-	startingPos?: number
+	startingPos?: StartingPos
 	borderRight?: boolean
 }) => css`
 	${gridItemSpans(span)}
-	${startingPos ? `grid-column-start: ${startingPos};` : ""}
+	${startingPos ? gridItemStartingPos(startingPos) : ""}
 	${borderRight ? borderRightStyle : ""}
 `


### PR DESCRIPTION
## What is the purpose of this change?

Teams have expressed an interest in how to lay out their page using the design system.

## What does this change?

This change adds a first pass at a `<Grid>` component.

**Usage example 1**

```jsx
<Grid>
  <GridItem span={{tablet: 3, desktop: 4}}>
    <Sidebar/>
  </GridItem>
  <GridItem span={{tablet: 9, desktop: 8}}>
    <Main/>
  </GridItem>
</Grid>
```

**Usage example 2**
```jsx
const sidebar = css`
    ${gridItem({ span: { tablet: 3, desktop: 4 } })}
`
const main = css`
    ${gridItem({ span: { tablet: 9, desktop: 8 } })}
`


render(
    <Grid>
        <div css={sidebar}></div>
        <div css={main}></div>
    </Grid>
)
```
