### PR TITLE
Button cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 .cache
 .DS_Store
+*.tgz

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -23,6 +23,7 @@
 		"rollup-plugin-node-resolve": "^5.2.0"
 	},
 	"files": [
+		"dist/*.js",
 		"index.tsx",
 		"styles.ts",
 		"themes.ts"

--- a/packages/button/rollup.config.js
+++ b/packages/button/rollup.config.js
@@ -22,6 +22,8 @@ module.exports = {
 		"@emotion/css",
 		"@guardian/src-foundations",
 		"@guardian/src-foundations/accessibility",
+		"@guardian/src-foundations/themes",
+		"@guardian/src-foundations/typography",
 	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }


### PR DESCRIPTION

## What does this change?

- ignore tarballs (e.g. from `yarn pack`)
- externalise more foundations
- include dist files in `yarn publish`

