### PR TITLE
Add repo to package info

### DIFF
--- a/packages/foundations/package.json
+++ b/packages/foundations/package.json
@@ -3,6 +3,10 @@
 	"version": "0.9.0",
 	"main": "foundations.js",
 	"module": "foundations.esm.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/guardian/source-components.git"
+  },
 	"scripts": {
 		"build": "yarn clean && tsc && rollup --config",
 		"watch": "rollup --config --watch",


### PR DESCRIPTION
## What is the purpose of this change?

This repo is a bit hard to find as the name doesn't relate to src-foundations. Thought it would be helpful to include this in the package.json so that it shows up in npm etc.

## What does this change?

Adds repo info to `package.json` for src-foundations.