### PR TITLE
Grid API refinements

### DIFF
--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -13,57 +13,41 @@ $ yarn add @guardian/src-grid @guardian/src-foundations
 **Note:** this component does not currently have support for Internet Explorer
 
 ```js
-import { Grid, GridItem, gridItem } from "@guardian/src-grid"
+import { GridRow, GridItem } from "@guardian/src-grid"
 
 const Article = () => (
-    <Grid>
-        <GridItem span={{ tablet: 3, desktop: 4 }}>
+    <GridRow breakpoints={["mobile", "tablet", "desktop", "wide"]}>
+        <GridItem span={[0, 3, 3, 4]} borderRight={true}>
             <Sidebar />
         </GridItem>
-        <GridItem span={{ tablet: 9, desktop: 8 }}>
+        <GridItem span={[4, 9, 9, 12]}>
             <Main />
         </GridItem>
-    </Grid>
-)
-
-const sidebar = css`
-    ${gridItem({ span: { tablet: 3, desktop: 4 } })}
-`
-const main = css`
-    ${gridItem({ span: { tablet: 9, desktop: 8 } })}
-`
-
-const ArticleAlt = () => (
-    <Grid>
-        <div css={sidebar}></div>
-        <div css={main}></div>
-    </Grid>
+    </GridRow>
 )
 ```
+
+## `GridRow` Props
+
+### `breakpoints`
+
+**`GridBreakpoints[]`**
+
+A list of breakpoints at which grid column span may change. GridRow currently
+supports changes at `"mobile"`, `"tablet"`, `"desktop"` and `"wide"` breakpoints.
+Any of these may be omitted.
 
 ## `GridItem` Props
 
 ### `span`
 
-**`{ mobile?: number, tablet?: number, desktop?: number, wide?: number }`**
+**`number[]`**
 
-The number of columns a grid item should span at the specified breakpoints.
+The number of columns a grid item should span. Corresponds to the `breakpoints` list
+in `GridRow` props.
 
-Adopt a mobile-first mindset when using this prop. If a span for a narrow breakpoint is specified (e.g. `mobile`),
-wider breakpoints will also use this span value unless it is specifically overridden.
-
-The narrowest specified breakpoint will be the first breakpoint at which the grid item is visible. At narrower
-breakpoints, the grid item will have `display: none` applied to it.
-
-### `startingPos`
-
-**`{ mobile?: number, tablet?: number, desktop?: number, wide?: number }`**
-
-The column number at which the grid item should begin at the specified breakpoints. If this props is omitted, the grid
-item will begin at the next available column.
-
-Adopt a mobile-first mindset when using this prop. If a starting position for a narrow breakpoint is specified (e.g. `mobile`),
-wider breakpoints will also use this starting position value unless it is specifically overridden.
+When a col span of 0 is specified for a particular breakpoint, the grid item will have
+`display: none` applied to it.
 
 ### `borderRight`
 

--- a/packages/grid/index.tsx
+++ b/packages/grid/index.tsx
@@ -37,18 +37,27 @@ const GridRow = ({
 			),
 		]}
 	>
-		{children}
+		{React.Children.map(children, child =>
+			React.cloneElement(child, {
+				breakpoints,
+				spans: child.props.spans,
+			}),
+		)}
 	</div>
 )
 
 const GridItem = ({
-	span,
+	breakpoints,
+	spans,
 	children,
 }: {
-	span: number[]
+	breakpoints: GridBreakpoint[]
+	spans: number[]
 	children: JSX.Element | JSX.Element[]
 }) => {
-	return <div css={gridItem}>{children}</div>
+	return <div css={gridItem({ breakpoints, spans })}>{children}</div>
 }
+
+GridItem.defaultProps = { breakpoints: [] }
 
 export { GridRow, GridItem }

--- a/packages/grid/index.tsx
+++ b/packages/grid/index.tsx
@@ -7,6 +7,7 @@ import {
 	gridRowWide,
 	gridItem,
 	GridBreakpoint,
+	borderRightStyle,
 } from "./styles"
 import { SerializedStyles } from "@emotion/css"
 
@@ -76,18 +77,25 @@ const GridRow = ({
 }
 
 const GridItem = ({
-	breakpoints,
 	spans,
+	borderRight,
+	breakpoints,
 	startingPositions,
 	children,
 }: {
-	breakpoints: GridBreakpoint[]
 	spans: number[]
+	borderRight?: boolean
 	startingPositions: number[]
+	breakpoints: GridBreakpoint[]
 	children: JSX.Element | JSX.Element[]
 }) => {
 	return (
-		<div css={gridItem({ breakpoints, spans, startingPositions })}>
+		<div
+			css={[
+				gridItem({ breakpoints, spans, startingPositions }),
+				borderRight ? borderRightStyle : "",
+			]}
+		>
 			{children}
 		</div>
 	)

--- a/packages/grid/index.tsx
+++ b/packages/grid/index.tsx
@@ -26,38 +26,73 @@ const GridRow = ({
 }: {
 	breakpoints: GridBreakpoint[]
 	children: JSX.Element | JSX.Element[]
-}) => (
-	<div
-		css={[
-			gridRow,
-			breakpoints.reduce(
-				(acc, breakpoint) =>
-					acc.concat([gridRowBreakpoints[breakpoint]]),
-				[] as SerializedStyles[],
-			),
-		]}
-	>
-		{React.Children.map(children, child =>
-			React.cloneElement(child, {
-				breakpoints,
-				spans: child.props.spans,
-			}),
-		)}
-	</div>
-)
+}) => {
+	// Create an array with an entry for each child
+	// Each entry is an array of starting positions,
+	// all initially set to 1
+	const startingPosForChildren: number[][] = []
+
+	for (let i = 0; i < React.Children.count(children); i += 1) {
+		startingPosForChildren.push(breakpoints.map(() => 1))
+	}
+
+	React.Children.forEach(children, (child, index) => {
+		// We always set the starting position of the next
+		// child, so if this is the last child, we're done
+		if (index === React.Children.count(children) - 1) {
+			return
+		}
+
+		const startingPosForThisChild = startingPosForChildren[index]
+		const startingPosForNextChild = startingPosForChildren[index + 1]
+
+		// The starting position of the next child is the starting position
+		// of the current child, plus the current child's span
+		child.props.spans.forEach((span: number, i: number) => {
+			startingPosForNextChild[i] = startingPosForThisChild[i] + span
+		})
+	})
+
+	return (
+		<div
+			css={[
+				gridRow,
+				breakpoints.reduce(
+					(acc, breakpoint) =>
+						acc.concat([gridRowBreakpoints[breakpoint]]),
+					[] as SerializedStyles[],
+				),
+			]}
+		>
+			{React.Children.map(children, (child, index) =>
+				React.cloneElement(child, {
+					breakpoints,
+					spans: child.props.spans,
+					startingPositions: startingPosForChildren[index],
+				}),
+			)}
+		</div>
+	)
+}
 
 const GridItem = ({
 	breakpoints,
 	spans,
+	startingPositions,
 	children,
 }: {
 	breakpoints: GridBreakpoint[]
 	spans: number[]
+	startingPositions: number[]
 	children: JSX.Element | JSX.Element[]
 }) => {
-	return <div css={gridItem({ breakpoints, spans })}>{children}</div>
+	return (
+		<div css={gridItem({ breakpoints, spans, startingPositions })}>
+			{children}
+		</div>
+	)
 }
 
-GridItem.defaultProps = { breakpoints: [] }
+GridItem.defaultProps = { breakpoints: [], startingPositions: [] }
 
 export { GridRow, GridItem }

--- a/packages/grid/index.tsx
+++ b/packages/grid/index.tsx
@@ -1,24 +1,54 @@
 import React from "react"
-import { gridContainer, gridItem, Spans, StartingPos } from "./styles"
+import {
+	gridRow,
+	gridRowMobile,
+	gridRowTablet,
+	gridRowDesktop,
+	gridRowWide,
+	gridItem,
+	GridBreakpoint,
+} from "./styles"
+import { SerializedStyles } from "@emotion/css"
 
-const Grid = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
-	<div css={gridContainer}>{children}</div>
+type GridRowBreakpoints = {
+	[key in GridBreakpoint]: SerializedStyles
+}
+const gridRowBreakpoints: GridRowBreakpoints = {
+	mobile: gridRowMobile,
+	tablet: gridRowTablet,
+	desktop: gridRowDesktop,
+	wide: gridRowWide,
+}
+
+const GridRow = ({
+	breakpoints,
+	children,
+}: {
+	breakpoints: GridBreakpoint[]
+	children: JSX.Element | JSX.Element[]
+}) => (
+	<div
+		css={[
+			gridRow,
+			breakpoints.reduce(
+				(acc, breakpoint) =>
+					acc.concat([gridRowBreakpoints[breakpoint]]),
+				[] as SerializedStyles[],
+			),
+		]}
+	>
+		{children}
+	</div>
 )
 
 const GridItem = ({
 	span,
-	startingPos,
-	borderRight,
 	children,
 }: {
-	span: Spans
-	startingPos?: StartingPos
-	borderRight?: boolean
+	span: number[]
 	children: JSX.Element | JSX.Element[]
 }) => {
-	return (
-		<div css={gridItem({ span, startingPos, borderRight })}>{children}</div>
-	)
+	return <div css={gridItem}>{children}</div>
 }
 
-export { Grid, GridItem, gridItem }
+export { GridRow, GridItem }

--- a/packages/grid/styles.ts
+++ b/packages/grid/styles.ts
@@ -30,7 +30,7 @@ const gridColumns: GridColumns = {
 }
 
 const containerWidths: ContainerWidths = {
-	mobile: '100%',
+	mobile: "100%",
 	tablet: `${breakpoints.tablet}px`,
 	desktop: `${breakpoints.desktop}px`,
 	wide: `${breakpoints.wide}px`,
@@ -65,6 +65,49 @@ const [
 	`,
 )
 
-const gridItem = css``
+const gridItemSpans = ({
+	breakpoints,
+	spans,
+}: {
+	breakpoints: GridBreakpoint[]
+	spans: number[]
+}) => {
+	return css`
+		${breakpoints.reduce((acc, breakpoint, index) => {
+			if (spans[index] === 0) {
+				return `${acc}
+					${from[breakpoint]} {
+						display: none;
+					}
+				`
+			}
 
-export { gridRow, gridRowMobile, gridRowTablet, gridRowDesktop, gridRowWide  gridItem, GridBreakpoint }
+			return `${acc}
+				${from[breakpoint]} {
+					display: block;
+					grid-column-end: span ${spans[index]};
+				}
+			`
+		}, "")}
+	`
+}
+
+const gridItem = ({
+	breakpoints,
+	spans,
+}: {
+	breakpoints: GridBreakpoint[]
+	spans: number[]
+}) => css`
+	${gridItemSpans({ breakpoints, spans })}
+`
+
+export {
+	gridRow,
+	gridRowMobile,
+	gridRowTablet,
+	gridRowDesktop,
+	gridRowWide,
+	gridItem,
+	GridBreakpoint,
+}

--- a/packages/grid/styles.ts
+++ b/packages/grid/styles.ts
@@ -41,18 +41,20 @@ const containerWidths: ContainerWidths = {
 	wide: `${breakpoints.wide}px`,
 }
 
+const GUTTER_WIDTH = space[5]
+
 const gridRow = css`
 	@supports (display: grid) {
 		display: grid;
 	}
 
 	grid-auto-columns: max-content;
-	column-gap: ${space[5]}px;
+	column-gap: ${GUTTER_WIDTH}px;
 
 	/* horizontal padding is smaller on mobile */
 	padding: 0 ${space[3]}px;
 	${from.tablet} {
-		padding: 0 ${space[5]}px;
+		padding: 0 ${GUTTER_WIDTH}px;
 	}
 `
 
@@ -126,8 +128,8 @@ const gridItem = ({
 
 const borderRightStyle = css`
 	border-right: 1px solid ${palette.border.secondary};
-	padding-right: ${space[5] / 2}px;
-	margin-right: ${-space[5] / 2}px;
+	padding-right: ${GUTTER_WIDTH / 2}px;
+	margin-right: ${-GUTTER_WIDTH / 2}px;
 `
 
 export {

--- a/packages/grid/styles.ts
+++ b/packages/grid/styles.ts
@@ -11,12 +11,12 @@ type GridBreakpoint = Extract<
 	Breakpoint,
 	"mobile" | "tablet" | "desktop" | "wide"
 >
-const gridBreakpoints: readonly GridBreakpoint[] = <const>[
+const gridBreakpoints: readonly GridBreakpoint[] = [
 	"mobile",
 	"tablet",
 	"desktop",
 	"wide",
-]
+] as const
 type GridBreakpoints = typeof gridBreakpoints[number]
 
 type GridColumns = {

--- a/packages/grid/styles.ts
+++ b/packages/grid/styles.ts
@@ -72,34 +72,51 @@ const gridItemSpans = ({
 	breakpoints: GridBreakpoint[]
 	spans: number[]
 }) => {
-	return css`
-		${breakpoints.reduce((acc, breakpoint, index) => {
-			if (spans[index] === 0) {
-				return `${acc}
-					${from[breakpoint]} {
-						display: none;
-					}
-				`
-			}
-
+	return breakpoints.reduce((acc, breakpoint, index) => {
+		if (spans[index] === 0) {
 			return `${acc}
 				${from[breakpoint]} {
-					display: block;
-					grid-column-end: span ${spans[index]};
+					display: none;
 				}
 			`
-		}, "")}
-	`
+		}
+
+		return `${acc}
+			${from[breakpoint]} {
+				display: block;
+				grid-column-end: span ${spans[index]};
+			}
+		`
+	}, "")
+}
+
+const gridItemStartingPos = ({
+	breakpoints,
+	startingPositions,
+}: {
+	breakpoints: GridBreakpoint[]
+	startingPositions: number[]
+}) => {
+	return breakpoints.reduce((acc, breakpoint, index) => {
+		return `${acc}
+			${from[breakpoint]} {
+				grid-column-start: ${startingPositions[index]};
+			}
+		`
+	}, "")
 }
 
 const gridItem = ({
 	breakpoints,
 	spans,
+	startingPositions,
 }: {
 	breakpoints: GridBreakpoint[]
 	spans: number[]
+	startingPositions: number[]
 }) => css`
 	${gridItemSpans({ breakpoints, spans })}
+	${gridItemStartingPos({ breakpoints, startingPositions })}
 `
 
 export {

--- a/packages/grid/styles.ts
+++ b/packages/grid/styles.ts
@@ -1,5 +1,10 @@
 import { css } from "@emotion/core"
-import { Breakpoint, space, breakpoints } from "@guardian/src-foundations"
+import {
+	Breakpoint,
+	space,
+	breakpoints,
+	palette,
+} from "@guardian/src-foundations"
 import { from } from "@guardian/src-foundations/mq"
 
 type GridBreakpoint = Extract<
@@ -119,6 +124,12 @@ const gridItem = ({
 	${gridItemStartingPos({ breakpoints, startingPositions })}
 `
 
+const borderRightStyle = css`
+	border-right: 1px solid ${palette.border.secondary};
+	padding-right: ${space[5] / 2}px;
+	margin-right: ${-space[5] / 2}px;
+`
+
 export {
 	gridRow,
 	gridRowMobile,
@@ -127,4 +138,5 @@ export {
 	gridRowWide,
 	gridItem,
 	GridBreakpoint,
+	borderRightStyle,
 }

--- a/packages/grid/styles.ts
+++ b/packages/grid/styles.ts
@@ -1,16 +1,17 @@
 import { css } from "@emotion/core"
-import {
-	Breakpoint,
-	space,
-	breakpoints,
-	palette,
-} from "@guardian/src-foundations"
+import { Breakpoint, space, breakpoints } from "@guardian/src-foundations"
 import { from } from "@guardian/src-foundations/mq"
 
-const gridBreakpoints: readonly Extract<
+type GridBreakpoint = Extract<
 	Breakpoint,
-	"tablet" | "desktop" | "leftCol" | "wide"
->[] = ["tablet", "desktop", "leftCol", "wide"] as const
+	"mobile" | "tablet" | "desktop" | "wide"
+>
+const gridBreakpoints: readonly GridBreakpoint[] = <const>[
+	"mobile",
+	"tablet",
+	"desktop",
+	"wide",
+]
 type GridBreakpoints = typeof gridBreakpoints[number]
 
 type GridColumns = {
@@ -18,124 +19,52 @@ type GridColumns = {
 }
 
 type ContainerWidths = {
-	[key in GridBreakpoints]: number
+	[key in GridBreakpoints]: string
 }
 
 const gridColumns: GridColumns = {
+	mobile: 4,
 	tablet: 12,
 	desktop: 12,
-	leftCol: 14,
 	wide: 16,
 }
 
 const containerWidths: ContainerWidths = {
-	tablet: breakpoints.tablet,
-	desktop: breakpoints.desktop,
-	leftCol: breakpoints.leftCol,
-	wide: breakpoints.wide,
+	mobile: '100%',
+	tablet: `${breakpoints.tablet}px`,
+	desktop: `${breakpoints.desktop}px`,
+	wide: `${breakpoints.wide}px`,
 }
 
-export const gridContainer = css`
+const gridRow = css`
 	@supports (display: grid) {
 		display: grid;
 	}
 
-	padding: 0 ${space[3]}px;
 	grid-auto-columns: max-content;
 	column-gap: ${space[5]}px;
 
-	width: 100%;
-	grid-template-columns: repeat(4, 1fr);
-
+	/* horizontal padding is smaller on mobile */
+	padding: 0 ${space[3]}px;
 	${from.tablet} {
 		padding: 0 ${space[5]}px;
 	}
-
-	${gridBreakpoints.reduce((acc, breakpoint) => {
-		return `${acc}
-			${from[breakpoint]} {
-				width: ${containerWidths[breakpoint]}px;
-				grid-template-columns: repeat(${gridColumns[breakpoint]}, 1fr);
-			}
-		`
-	}, "")}
-`
-const borderRightStyle = css`
-	border-right: 1px solid ${palette.border.secondary};
-	padding-right: ${space[5] / 2}px;
-	margin-right: ${-space[5] / 2}px;
 `
 
-const gridItemBreakpoints: readonly Extract<
-	Breakpoint,
-	"mobile" | "tablet" | "desktop" | "leftCol" | "wide"
->[] = ["mobile", "tablet", "desktop", "leftCol", "wide"] as const
-type GridItemBreakpoints = typeof gridItemBreakpoints[number]
-
-export type Spans = {
-	[key in GridItemBreakpoints]?: number
-}
-
-export type StartingPos = {
-	[key in GridItemBreakpoints]?: number
-}
-
-const gridItemSpans = (spans: Spans) => {
-	let minimumBreakpointSet = false
-	let style = ""
-
-	for (let i = 0; i < gridItemBreakpoints.length; i += 1) {
-		const breakpoint = gridItemBreakpoints[i]
-
-		if (spans[breakpoint]) {
-			style = `${style}
-				${from[breakpoint]} {
-					display: block;
-					grid-column-end: span ${spans[breakpoint]};
-				}
-			`
-
-			if (!minimumBreakpointSet) {
-				minimumBreakpointSet = true
-			}
-		} else {
-			if (!minimumBreakpointSet) {
-				style = `${style}
-				${from[breakpoint]} {
-					display: none;
-				}
-			`
-			}
+const [
+	gridRowMobile,
+	gridRowTablet,
+	gridRowDesktop,
+	gridRowWide,
+] = gridBreakpoints.map(
+	breakpoint => css`
+		${from[breakpoint]} {
+			width: ${containerWidths[breakpoint]}px;
+			grid-template-columns: repeat(${gridColumns[breakpoint]}, 1fr);
 		}
-	}
+	`,
+)
 
-	return style
-}
+const gridItem = css``
 
-const gridItemStartingPos = (startingPos: StartingPos) => {
-	return gridItemBreakpoints.reduce((acc, breakpoint) => {
-		if (startingPos[breakpoint]) {
-			return `${acc}
-				${from[breakpoint]} {
-					grid-column-start: ${startingPos[breakpoint]};
-				}
-			`
-		}
-
-		return acc
-	}, "")
-}
-
-export const gridItem = ({
-	span,
-	startingPos,
-	borderRight = false,
-}: {
-	span: Spans
-	startingPos?: StartingPos
-	borderRight?: boolean
-}) => css`
-	${gridItemSpans(span)}
-	${startingPos ? gridItemStartingPos(startingPos) : ""}
-	${borderRight ? borderRightStyle : ""}
-`
+export { gridRow, gridRowMobile, gridRowTablet, gridRowDesktop, gridRowWide  gridItem, GridBreakpoint }


### PR DESCRIPTION
## What is the purpose of this change?

The API for the grid was difficult to get one's head around. This change simplifies the API significantly.

## What does this change?

Introduces an API for defining column spans at breakpoints specified at the grid container level.

```jsx
import { GridRow, GridItem } from "@guardian/src-grid"

const Article = () => (
    <GridRow breakpoints={['mobile', 'tablet', 'desktop', 'wide']}>
        <GridItem span={[0, 3, 3, 4]} borderRight={true}>
            <Sidebar />
        </GridItem>
        <GridItem span={[4, 9, 9, 12]}>
            <Main />
        </GridItem>
    </GridRow>
)
```

This change also renames the container to `GridRow` to help imply that the grid is not a full 2-dimensional grid, but a means of specifying column widths for horizontal siblings in a layout.
