### PR TITLE
Add support for IE10 and IE11 to grid

### DIFF
--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -10,8 +10,6 @@ $ yarn add @guardian/src-grid @guardian/src-foundations
 
 ## Use
 
-**Note:** this component does not currently have support for Internet Explorer
-
 ```js
 import { GridRow, GridItem } from "@guardian/src-grid"
 

--- a/packages/grid/styles.ts
+++ b/packages/grid/styles.ts
@@ -47,6 +47,7 @@ const gridRow = css`
 	@supports (display: grid) {
 		display: grid;
 	}
+	display: -ms-grid;
 
 	grid-auto-columns: max-content;
 	column-gap: ${GUTTER_WIDTH}px;
@@ -63,14 +64,17 @@ const [
 	gridRowTablet,
 	gridRowDesktop,
 	gridRowWide,
-] = gridBreakpoints.map(
-	breakpoint => css`
+] = gridBreakpoints.map(breakpoint => {
+	const msGridColumns = `-ms-grid-columns: (minmax(0, 1fr))[${gridColumns[breakpoint]}]`
+
+	return css`
 		${from[breakpoint]} {
 			width: ${containerWidths[breakpoint]}px;
 			grid-template-columns: repeat(${gridColumns[breakpoint]}, 1fr);
+			${msGridColumns};
 		}
-	`,
-)
+	`
+})
 
 const gridItemSpans = ({
 	breakpoints,
@@ -92,6 +96,7 @@ const gridItemSpans = ({
 			${from[breakpoint]} {
 				display: block;
 				grid-column-end: span ${spans[index]};
+				-ms-grid-column-span: ${spans[index]};,
 			}
 		`
 	}, "")
@@ -108,6 +113,11 @@ const gridItemStartingPos = ({
 		return `${acc}
 			${from[breakpoint]} {
 				grid-column-start: ${startingPositions[index]};
+				-ms-grid-column: ${
+					startingPositions[index] > 0
+						? startingPositions[index]
+						: gridColumns[breakpoint] + 2 + startingPositions[index]
+				};
 			}
 		`
 	}, "")
@@ -124,6 +134,7 @@ const gridItem = ({
 }) => css`
 	${gridItemSpans({ breakpoints, spans })}
 	${gridItemStartingPos({ breakpoints, startingPositions })}
+	-ms-grid-row: 1;
 `
 
 const borderRightStyle = css`

--- a/packages/grid/styles.ts
+++ b/packages/grid/styles.ts
@@ -47,6 +47,7 @@ const gridRow = css`
 	@supports (display: grid) {
 		display: grid;
 	}
+	/* stylelint-disable-next-line value-no-vendor-prefix */
 	display: -ms-grid;
 
 	grid-auto-columns: max-content;
@@ -133,7 +134,11 @@ const gridItem = ({
 	startingPositions: number[]
 }) => css`
 	${gridItemSpans({ breakpoints, spans })}
-	${gridItemStartingPos({ breakpoints, startingPositions })}
+	${gridItemStartingPos({
+		breakpoints,
+		startingPositions,
+	})}
+	/* stylelint-disable-next-line property-no-vendor-prefix */
 	-ms-grid-row: 1;
 `
 


### PR DESCRIPTION
## What is the purpose of this change?

To better support IE11, we should fallback to IE's original (non-standard) CSS grid implementation

## What does this change?

Adds vendor-prefixed fallbacks for the old IE grid specification.
