### PR TITLE
Expose typography types

### DIFF
--- a/packages/foundations/src/typography/index.ts
+++ b/packages/foundations/src/typography/index.ts
@@ -257,4 +257,11 @@ export {
 	headlineSizes,
 	bodySizes,
 	textSansSizes,
+	Category,
+	LineHeight,
+	FontWeight,
+	TitlepieceSizes,
+	HeadlineSizes,
+	BodySizes,
+	TextSansSizes,
 }


### PR DESCRIPTION
## What is the purpose of this change?

There was a request to expose more types associated with typography to make it easier to build custom typography helper functions.

cc @nicl 

## What does this change?

Exposes:

- Category
- LineHeight
- FontWeight
- TitlepieceSizes
- HeadlineSizes
- BodySizes
- TextSansSizes
