### PR TITLE
Make loose line height 1.5x font size

### DIFF
--- a/packages/foundations/src/theme.ts
+++ b/packages/foundations/src/theme.ts
@@ -8,7 +8,7 @@ const fonts = {
 		"GuardianTextSans, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif",
 }
 
-const lineHeights = [1.15, 1.35, 1.45]
+const lineHeights = [1.15, 1.35, 1.5]
 
 const fontWeights = [300, 400, 500, 700]
 


### PR DESCRIPTION
## What is the purpose of this change?

Makes line height of body text (AKA loose) [WCAG 2.1 AAA compliant](https://www.w3.org/TR/WCAG21/#visual-presentation). This will help people experiencing low vision conditions, as well as people with cognitive concerns such as Dyslexia.

## What does this change?

Boosts loose line height  from 1.45x to 1.5x font size
