### PR TITLE
Grid improvements

### DIFF
--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -29,7 +29,7 @@ const Article = () => (
 
 ### `breakpoints`
 
-**`GridBreakpoints[]`**
+**`GridBreakpoints[]`** _= ["mobile", "tablet", "desktop", "wide"]_
 
 A list of breakpoints at which grid column span may change. GridRow currently
 supports changes at `"mobile"`, `"tablet"`, `"desktop"` and `"wide"` breakpoints.

--- a/packages/grid/index.tsx
+++ b/packages/grid/index.tsx
@@ -33,9 +33,9 @@ const GridRow = ({
 	// all initially set to 1
 	const startingPosForChildren: number[][] = []
 
-	for (let i = 0; i < React.Children.count(children); i += 1) {
+	React.Children.forEach(children, () => {
 		startingPosForChildren.push(breakpoints.map(() => 1))
-	}
+	})
 
 	React.Children.forEach(children, (child, index) => {
 		// We always set the starting position of the next

--- a/packages/grid/index.tsx
+++ b/packages/grid/index.tsx
@@ -101,6 +101,10 @@ const GridItem = ({
 	)
 }
 
-GridItem.defaultProps = { breakpoints: [], startingPositions: [] }
+GridRow.defaultProps = { breakpoints: ["mobile", "tablet", "desktop", "wide"] }
+GridItem.defaultProps = {
+	breakpoints: ["mobile", "tablet", "desktop", "wide"],
+	startingPositions: [],
+}
 
 export { GridRow, GridItem }


### PR DESCRIPTION
## What is the purpose of this change?

`GridRow` was missing sensible default breakpoints.

## What does this change?

The default breakpoints for `GridRow` are now `["mobile", "tablet", "desktop", "wide"]`

This change also refactors the setting of the `startingPositions` to make it more declarative.