### PR TITLE
Slim down link button API

### DIFF
--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -11,11 +11,14 @@ $ yarn add @guardian/src-button @guardian/src-foundations
 ## Use
 
 ```js
-import { Button, LinkButton } from "@guardian/src-button"
+import { LinkButton, Button } from "@guardian/src-button"
 import { SvgCheckmark, SvgArrowRightStraight } from "@guardian/src-svgs"
 
 const Form = () => (
     <form>
+        <LinkButton priority="primary" size="default" href="/read-more">
+            Read more
+        </LinkButton>
         <Button
             priority="primary"
             size="default"
@@ -27,20 +30,25 @@ const Form = () => (
         >
             Click me
         </Button>
-        <LinkButton
-            priority="primary"
-            size="default"
-            icon={<SvgArrowRightStraight />}
-            iconSide="right"
-            href="/read-more"
-        >
-            Read more
-        </LinkButton>
     </form>
 )
 ```
 
-## Props
+## `LinkButton` Props
+
+### `priority`
+
+**`"primary" | "secondary"`** _= "primary"_
+
+Informs users of how important an action is
+
+### `size`
+
+**`"default" | "small"`** _= "default"_
+
+Reflects the prominance of the action
+
+## `Button` Props
 
 ### `priority`
 

--- a/packages/button/index.tsx
+++ b/packages/button/index.tsx
@@ -110,7 +110,9 @@ const LinkButton = ({
 	href: string
 	children?: ReactNode
 }) => {
-	const buttonContents = [children].concat([<SvgArrowRightStraight />])
+	const buttonContents = [children].concat([
+		React.cloneElement(<SvgArrowRightStraight />, { key: "svg" }),
+	])
 
 	return (
 		<a

--- a/packages/button/index.tsx
+++ b/packages/button/index.tsx
@@ -27,6 +27,7 @@ export {
 export type Priority = "primary" | "secondary" | "tertiary"
 type IconSide = "left" | "right"
 type Size = "default" | "small"
+type LinkButtonPriority = Extract<"primary" | "secondary", Priority>
 
 const priorities: {
 	[key in Priority]: ({ button }: { button: ButtonTheme }) => SerializedStyles
@@ -104,7 +105,7 @@ const LinkButton = ({
 	children,
 	...props
 }: {
-	priority: Priority
+	priority: LinkButtonPriority
 	size: Size
 	href: string
 	children?: ReactNode

--- a/packages/button/index.tsx
+++ b/packages/button/index.tsx
@@ -15,6 +15,7 @@ import {
 } from "./styles"
 import { SerializedStyles } from "@emotion/css"
 import { ButtonTheme } from "@guardian/src-foundations/themes"
+import { SvgArrowRightStraight } from "@guardian/src-svgs"
 export {
 	buttonLight,
 	buttonBrand,
@@ -100,23 +101,15 @@ const Button = ({
 const LinkButton = ({
 	priority,
 	size,
-	icon: iconSvg,
-	iconSide,
 	children,
 	...props
 }: {
 	priority: Priority
 	size: Size
-	icon?: ReactElement
-	iconSide: IconSide
 	href: string
 	children?: ReactNode
 }) => {
-	const buttonContents = [children]
-
-	if (iconSvg) {
-		buttonContents.push(React.cloneElement(iconSvg, { key: "svg" }))
-	}
+	const buttonContents = [children].concat([<SvgArrowRightStraight />])
 
 	return (
 		<a
@@ -124,8 +117,8 @@ const LinkButton = ({
 				button,
 				sizes[size],
 				priorities[priority](theme.button && theme),
-				iconSvg ? iconSizes[size] : "",
-				iconSvg && children ? iconSides[iconSide] : "",
+				iconSizes[size],
+				children ? iconSides.right : "",
 				!children ? iconOnlySizes[size] : "",
 			]}
 			{...props}
@@ -145,7 +138,6 @@ const defaultButtonProps = {
 const defaultLinkButtonProps = {
 	priority: "primary",
 	size: "default",
-	iconSide: "right",
 }
 
 Button.defaultProps = { ...defaultButtonProps }

--- a/packages/button/index.tsx
+++ b/packages/button/index.tsx
@@ -40,8 +40,8 @@ const priorities: {
 const iconSides: {
 	[key in IconSide]: SerializedStyles
 } = {
-	right: iconLeft,
-	left: iconRight,
+	right: iconRight,
+	left: iconLeft,
 }
 const sizes: {
 	[key in Size]: SerializedStyles

--- a/packages/button/stories.tsx
+++ b/packages/button/stories.tsx
@@ -46,9 +46,6 @@ const linkButtons = [
 	<LinkButton href="#" priority="secondary">
 		Secondary
 	</LinkButton>,
-	<LinkButton href="#" priority="tertiary">
-		Tertiary
-	</LinkButton>,
 ]
 const textIconLinkButtons = [
 	<LinkButton href="#">Link styled as a button</LinkButton>,

--- a/packages/button/stories.tsx
+++ b/packages/button/stories.tsx
@@ -4,11 +4,7 @@ import {
 	storybookBackgrounds,
 	WithBackgroundToggle,
 } from "@guardian/src-helpers"
-import {
-	SvgCheckmark,
-	SvgArrowRightStraight,
-	SvgClose,
-} from "@guardian/src-svgs"
+import { SvgCheckmark, SvgClose } from "@guardian/src-svgs"
 import { size } from "@guardian/src-foundations"
 import {
 	Button,
@@ -55,9 +51,7 @@ const linkButtons = [
 	</LinkButton>,
 ]
 const textIconLinkButtons = [
-	<LinkButton href="#" icon={<SvgArrowRightStraight />}>
-		Right aligned
-	</LinkButton>,
+	<LinkButton href="#">Link styled as a button</LinkButton>,
 ]
 /* eslint-enable react/jsx-key */
 

--- a/packages/button/stories.tsx
+++ b/packages/button/stories.tsx
@@ -28,9 +28,9 @@ const sizeButtons = [
 	<Button size="small">Small</Button>,
 ]
 const textIconButtons = [
-	<Button icon={<SvgCheckmark />}>Left aligned</Button>,
+	<Button icon={<SvgCheckmark />}>Icon to the left</Button>,
 	<Button iconSide="right" icon={<SvgCheckmark />}>
-		Right aligned
+		Icon to the right
 	</Button>,
 ]
 const iconButtons = [

--- a/packages/button/styles.ts
+++ b/packages/button/styles.ts
@@ -94,13 +94,13 @@ export const iconSmall = css`
 	}
 `
 
-export const iconLeft = css`
+export const iconRight = css`
 	svg {
 		margin: 0 ${-size.large / 8}px 0 ${size.large / 4}px;
 	}
 `
 
-export const iconRight = css`
+export const iconLeft = css`
 	flex-direction: row-reverse;
 	svg {
 		margin: 0 ${size.large / 4}px 0 ${-size.large / 8}px;


### PR DESCRIPTION
## What is the purpose of this change?

- The right arrow icon should always be applied to link buttons (this is my interpretation of [this best practice recommendation](https://zeroheight.com/2a1e5182b/p/435225/t/53fa17))
- The arrow icon should always be aligned to the right
- Tertiary link buttons are superfluous, look weird and should not be supported

## What does this change?

- Add the right arrow SVG icon to the link button by default
- Exclude tertiary from the link button priorties
- Some refactoring of the left and right icon styles and storybook
- Updated docs
