### PR TITLE
Add icon nudge animation

### DIFF
--- a/packages/button/index.tsx
+++ b/packages/button/index.tsx
@@ -12,6 +12,7 @@ import {
 	iconRight,
 	iconOnlyDefault,
 	iconOnlySmall,
+	iconNudgeAnimation,
 } from "./styles"
 import { SerializedStyles } from "@emotion/css"
 import { ButtonTheme } from "@guardian/src-foundations/themes"
@@ -110,10 +111,6 @@ const LinkButton = ({
 	href: string
 	children?: ReactNode
 }) => {
-	const buttonContents = [children].concat([
-		React.cloneElement(<SvgArrowRightStraight />, { key: "svg" }),
-	])
-
 	return (
 		<a
 			css={theme => [
@@ -123,10 +120,12 @@ const LinkButton = ({
 				iconSizes[size],
 				children ? iconSides.right : "",
 				!children ? iconOnlySizes[size] : "",
+				iconNudgeAnimation,
 			]}
 			{...props}
 		>
-			{buttonContents}
+			{children}
+			<SvgArrowRightStraight />
 		</a>
 	)
 }

--- a/packages/button/stories.tsx
+++ b/packages/button/stories.tsx
@@ -47,9 +47,6 @@ const linkButtons = [
 		Secondary
 	</LinkButton>,
 ]
-const textIconLinkButtons = [
-	<LinkButton href="#">Link styled as a button</LinkButton>,
-]
 /* eslint-enable react/jsx-key */
 
 const flexStart = css`
@@ -229,12 +226,3 @@ export const priorityLinkButtons = () => (
 	</div>
 )
 priorityLinkButtons.story = { name: "priority link buttons" }
-
-export const textAndIconLinkButtons = () => (
-	<div css={flexStart}>
-		{textIconLinkButtons.map((button, index) => (
-			<div key={index}>{button}</div>
-		))}
-	</div>
-)
-textAndIconLinkButtons.story = { name: "text and icon link buttons" }

--- a/packages/button/styles.ts
+++ b/packages/button/styles.ts
@@ -1,5 +1,5 @@
 import { css } from "@emotion/core"
-import { size, transitions } from "@guardian/src-foundations"
+import { size, space, transitions } from "@guardian/src-foundations"
 import { buttonLight, ButtonTheme } from "@guardian/src-foundations/themes"
 import { textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
@@ -115,4 +115,17 @@ export const iconOnlyDefault = css`
 export const iconOnlySmall = css`
 	width: ${size.medium}px;
 	justify-content: center;
+`
+
+export const iconNudgeAnimation = css`
+	svg {
+		transform: translate(0, 0);
+		transition: ${transitions.short};
+	}
+	&:hover,
+	&:focus {
+		svg {
+			transform: translate(${space[1] / 2}px, 0);
+		}
+	}
 `


### PR DESCRIPTION
## What is the purpose of this change?

There's a cute little nudge animation that happens on hover and focus of link buttons on theguardian.com. We should replicate this animation in the design system.

## What does this change?

Adds nudge animation

## Design

### Screenshots

![Dec-16-2019 11-06-29](https://user-images.githubusercontent.com/5931528/70902189-27e4aa80-1ff4-11ea-9ff8-9318e9f0a229.gif)

