### PR TITLE
Hide link button icon by default

### DIFF
--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -16,7 +16,12 @@ import { SvgCheckmark, SvgArrowRightStraight } from "@guardian/src-svgs"
 
 const Form = () => (
     <form>
-        <LinkButton priority="primary" size="default" href="/read-more">
+        <LinkButton
+            priority="primary"
+            size="default"
+            showIcon={true}
+            href="/read-more"
+        >
             Read more
         </LinkButton>
         <Button
@@ -47,6 +52,12 @@ Informs users of how important an action is
 **`"default" | "small"`** _= "default"_
 
 Reflects the prominance of the action
+
+### `showIcon`
+
+**`boolean`** _= false_
+
+Whether to show the arrow icon in this button
 
 ## `Button` Props
 

--- a/packages/button/index.tsx
+++ b/packages/button/index.tsx
@@ -103,31 +103,48 @@ const Button = ({
 const LinkButton = ({
 	priority,
 	size,
+	showIcon,
 	children,
 	...props
 }: {
 	priority: LinkButtonPriority
 	size: Size
+	showIcon: boolean
 	href: string
 	children?: ReactNode
 }) => {
-	return (
-		<a
-			css={theme => [
-				button,
-				sizes[size],
-				priorities[priority](theme.button && theme),
-				iconSizes[size],
-				children ? iconSides.right : "",
-				!children ? iconOnlySizes[size] : "",
-				iconNudgeAnimation,
-			]}
-			{...props}
-		>
-			{children}
-			<SvgArrowRightStraight />
-		</a>
-	)
+	if (showIcon) {
+		return (
+			<a
+				css={theme => [
+					button,
+					sizes[size],
+					priorities[priority](theme.button && theme),
+					iconSizes[size],
+					children ? iconSides.right : "",
+					!children ? iconOnlySizes[size] : "",
+					iconNudgeAnimation,
+				]}
+				{...props}
+			>
+				{children}
+				<SvgArrowRightStraight />
+			</a>
+		)
+	} else {
+		return (
+			<a
+				css={theme => [
+					button,
+					sizes[size],
+					priorities[priority](theme.button && theme),
+				]}
+				{...props}
+			>
+				{children}
+			</a>
+		)
+	}
 }
 
 const defaultButtonProps = {
@@ -140,6 +157,7 @@ const defaultButtonProps = {
 const defaultLinkButtonProps = {
 	priority: "primary",
 	size: "default",
+	showIcon: false,
 }
 
 Button.defaultProps = { ...defaultButtonProps }

--- a/packages/button/stories.tsx
+++ b/packages/button/stories.tsx
@@ -5,7 +5,7 @@ import {
 	WithBackgroundToggle,
 } from "@guardian/src-helpers"
 import { SvgCheckmark, SvgClose } from "@guardian/src-svgs"
-import { size } from "@guardian/src-foundations"
+import { size, space } from "@guardian/src-foundations"
 import {
 	Button,
 	LinkButton,
@@ -44,6 +44,14 @@ const iconButtons = [
 const linkButtons = [
 	<LinkButton href="#">Primary</LinkButton>,
 	<LinkButton href="#" priority="secondary">
+		Secondary
+	</LinkButton>,
+]
+const iconLinkButtons = [
+	<LinkButton href="#" showIcon={true}>
+		Primary
+	</LinkButton>,
+	<LinkButton href="#" showIcon={true} priority="secondary">
 		Secondary
 	</LinkButton>,
 ]
@@ -218,11 +226,26 @@ iconOnly.story = {
 	name: "icon only",
 }
 
+const spacer = css`
+	margin-bottom: ${space[3]}px;
+`
+
 export const priorityLinkButtons = () => (
-	<div css={flexStart}>
-		{linkButtons.map((button, index) => (
-			<div key={index}>{button}</div>
-		))}
-	</div>
+	<>
+		<div css={spacer}>
+			<div css={flexStart}>
+				{linkButtons.map((button, index) => (
+					<div key={index}>{button}</div>
+				))}
+			</div>
+		</div>
+		<div css={spacer}>
+			<div css={flexStart}>
+				{iconLinkButtons.map((button, index) => (
+					<div key={index}>{button}</div>
+				))}
+			</div>
+		</div>
+	</>
 )
 priorityLinkButtons.story = { name: "priority link buttons" }


### PR DESCRIPTION
## What is the purpose of this change?

We don't want arrow icons to appear everywhere. We should hide this icon unless specified in the design.

## What does this change?

Adds a `showIcon` prop that is false by default. When true, the right arrow icon is shown in the button.
