### PR TITLE
Checkbox: supporting text

### DIFF
--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -19,9 +19,14 @@ const Form = () => (
             <Checkbox
                 value="today-uk"
                 label="Guardian Today: UK"
+                supporting="The headlines, the analysis, the debate. Get the whole picture from a source you trust."
                 defaultChecked
             />
-            <Checkbox value="today-us" label="Guardian Today: US" />
+            <Checkbox
+                value="today-us"
+                label="Guardian Today: US"
+                supporting="Cut through the noise. Get straight to the heart of the day’s breaking news in double-quick time."
+            />
         </CheckboxGroup>
     </form>
 )

--- a/packages/checkbox/index.tsx
+++ b/packages/checkbox/index.tsx
@@ -8,6 +8,7 @@ import {
 	labelTextWithSupportingText,
 	supportingText,
 	tick,
+	tickWithSupportingText,
 	errorCheckbox,
 } from "./styles"
 import { InlineError } from "@guardian/src-inline-error"
@@ -80,7 +81,7 @@ const Checkbox = ({
 				aria-invalid={error}
 				{...props}
 			/>
-			<span css={tick} />
+			<span css={[tick, supporting ? tickWithSupportingText : ""]} />
 			{supporting ? (
 				<div>
 					<LabelText hasSupportingText={true}>

--- a/packages/checkbox/index.tsx
+++ b/packages/checkbox/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from "react"
 import {
-	group,
+	fieldset,
 	label,
 	labelWithSupportingText,
 	checkbox,
@@ -24,7 +24,7 @@ const CheckboxGroup = ({
 	children: JSX.Element | JSX.Element[]
 }) => {
 	return (
-		<div css={group} {...props}>
+		<fieldset css={fieldset} {...props}>
 			{typeof error === "string" && <InlineError>{error}</InlineError>}
 			{React.Children.map(children, child => {
 				return React.cloneElement(
@@ -34,7 +34,7 @@ const CheckboxGroup = ({
 					}),
 				)
 			})}
-		</div>
+		</fieldset>
 	)
 }
 

--- a/packages/checkbox/index.tsx
+++ b/packages/checkbox/index.tsx
@@ -20,18 +20,12 @@ const CheckboxGroup = ({
 }: {
 	name: string
 	error?: boolean | string
-	children: ReactNode
+	children: JSX.Element | JSX.Element[]
 }) => {
 	return (
 		<div css={group} {...props}>
 			{typeof error === "string" && <InlineError>{error}</InlineError>}
 			{React.Children.map(children, child => {
-				if (!React.isValidElement(child)) {
-					// Consumer is probably passing a text node as a child
-					// TODO: Pass error to terminal
-					return <div />
-				}
-
 				return React.cloneElement(
 					child,
 					Object.assign(error ? { error: true } : {}, {

--- a/packages/checkbox/stories.tsx
+++ b/packages/checkbox/stories.tsx
@@ -7,6 +7,7 @@ export default {
 	title: "Checkbox",
 }
 
+/* eslint-disable react/jsx-key */
 const checkboxes = [
 	<Checkbox label="Guardian Today: UK" value="today_uk" />,
 	<Checkbox label="Guardian Today: US" value="today_us" />,
@@ -30,6 +31,7 @@ const checkboxesWithSupportingText = [
 		supporting="Learn from leading minds at our Guardian live events, including discussions and debates, courses and training"
 	/>,
 ]
+/* eslint-enable react/jsx-key */
 
 const defaultLight = () => (
 	<CheckboxGroup name="emails">

--- a/packages/checkbox/stories.tsx
+++ b/packages/checkbox/stories.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { css } from "@emotion/core"
 
 import { CheckboxGroup, Checkbox } from "./index"
 
@@ -6,10 +7,35 @@ export default {
 	title: "Checkbox",
 }
 
+const checkboxes = [
+	<Checkbox label="Guardian Today: UK" value="today_uk" />,
+	<Checkbox label="Guardian Today: US" value="today_us" />,
+]
+
+const checkboxesWithSupportingText = [
+	<Checkbox
+		value="jobs"
+		label="Jobs"
+		supporting="Receive tips, Job Match recommendations, and advice from Guardian Jobs on taking your next career step."
+	/>,
+	<Checkbox
+		value="holidays"
+		label="Holidays & Vacations"
+		supporting="Ideas and inspiration for your next trip away, as well as the latest offers from Guardian Holidays"
+		defaultChecked
+	/>,
+	<Checkbox
+		value="events"
+		label="Events & Masterclasses"
+		supporting="Learn from leading minds at our Guardian live events, including discussions and debates, courses and training"
+	/>,
+]
+
 const defaultLight = () => (
 	<CheckboxGroup name="emails">
-		<Checkbox label="Guardian Today: UK" value="today_uk" />
-		<Checkbox label="Guardian Today: US" value="today_us" />
+		{checkboxes.map((checkbox, index) =>
+			React.cloneElement(checkbox, { key: index }),
+		)}
 	</CheckboxGroup>
 )
 
@@ -17,4 +43,22 @@ defaultLight.story = {
 	name: "default light",
 }
 
-export { defaultLight }
+const narrow = css`
+	width: 30rem;
+`
+
+const supportingTextLight = () => (
+	<div css={narrow}>
+		<CheckboxGroup name="emails">
+			{checkboxesWithSupportingText.map((checkbox, index) =>
+				React.cloneElement(checkbox, { key: index }),
+			)}
+		</CheckboxGroup>
+	</div>
+)
+
+supportingTextLight.story = {
+	name: "supporting text light",
+}
+
+export { defaultLight, supportingTextLight }

--- a/packages/checkbox/styles.ts
+++ b/packages/checkbox/styles.ts
@@ -3,10 +3,11 @@ import { palette, space, size, transitions } from "@guardian/src-foundations"
 import { textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
 
-export const group = css`
+export const fieldset = css`
 	display: flex;
 	justify-content: flex-start;
 	flex-direction: column;
+	border: 0;
 `
 
 export const label = css`

--- a/packages/checkbox/styles.ts
+++ b/packages/checkbox/styles.ts
@@ -10,10 +10,11 @@ export const group = css`
 `
 
 export const label = css`
+	flex: 0;
 	position: relative;
-	cursor: pointer;
 	display: flex;
 	align-items: center;
+	cursor: pointer;
 	height: ${size.large}px;
 
 	&:hover {
@@ -25,13 +26,14 @@ export const label = css`
 
 export const labelWithSupportingText = css`
 	align-items: flex-start;
-	margin-bottom: ${space[2]}px;
+	margin-bottom: ${space[3]}px;
 `
 
 export const checkbox = css`
-	cursor: pointer;
+	flex: 1 0 auto;
 	box-sizing: border-box;
 	display: inline-block;
+	cursor: pointer;
 	width: ${size.small}px;
 	height: ${size.small}px;
 	margin: 0 ${space[1]}px 0 0;
@@ -96,11 +98,11 @@ export const labelText = css`
 `
 
 export const labelTextWithSupportingText = css`
-	${textSans.medium({ fontWeight: "bold" })};
+	${textSans.medium()};
 `
 
 export const supportingText = css`
-	${textSans.medium()};
+	${textSans.small()};
 	color: ${palette.text.secondary};
 `
 
@@ -142,6 +144,12 @@ export const tick = css`
 			width: 2px;
 			transition-delay: 0.1s;
 		}
+	}
+`
+
+export const tickWithSupportingText = css`
+	@supports (appearance: none) {
+		top: 5px;
 	}
 `
 

--- a/packages/checkbox/styles.ts
+++ b/packages/checkbox/styles.ts
@@ -10,12 +10,11 @@ export const group = css`
 `
 
 export const label = css`
-	flex: 0;
 	position: relative;
 	display: flex;
 	align-items: center;
 	cursor: pointer;
-	height: ${size.large}px;
+	min-height: ${size.large}px;
 
 	&:hover {
 		input {


### PR DESCRIPTION
## What is the purpose of this change?

It should be possible to add supporting text to a checkbox label

## What does this change?

- provide better styling for checkbox supporting text
- add Storybook story for supporting text
- fix some layout bugs related to missing flex values
- provide more strict typing around children of a CheckboxGroup

## Design

### Screenshots

![Screenshot 2019-12-16 at 14 26 50](https://user-images.githubusercontent.com/5931528/70914551-1e693b80-2010-11ea-896f-95f4c486fcb6.png)


### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
