### PR TITLE
Prevent checkboxes from growing in wide containers

### DIFF
--- a/packages/checkbox/styles.ts
+++ b/packages/checkbox/styles.ts
@@ -30,7 +30,7 @@ export const labelWithSupportingText = css`
 `
 
 export const checkbox = css`
-	flex: 1 0 auto;
+	flex: 0 0 auto;
 	box-sizing: border-box;
 	display: inline-block;
 	cursor: pointer;


### PR DESCRIPTION
## What is the purpose of this change?

Fixes bug in which checkboxes were growing in wide containers.

## What does this change?

Sets `flex-grow` to 0 in checkbox styles
