### PR TITLE
Checkbox: indeterminate state

### DIFF
--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -59,3 +59,9 @@ Appears to the right of the checkbox
 **`string`**
 
 Additional text that appears below the label
+
+### `isIndeterminate`
+
+**`boolean`**
+
+Whether checkbox is in an indeterminate ("mixed") state

--- a/packages/checkbox/index.tsx
+++ b/packages/checkbox/index.tsx
@@ -66,11 +66,13 @@ const Checkbox = ({
 	value,
 	supporting,
 	error,
+	isIndeterminate,
 	...props
 }: {
 	label: string
 	value: string
 	supporting?: string
+	isIndeterminate: boolean
 	error: boolean
 }) => {
 	return (
@@ -79,6 +81,11 @@ const Checkbox = ({
 				css={[checkbox, error ? errorCheckbox : ""]}
 				value={value}
 				aria-invalid={error}
+				ref={el => {
+					if (el) {
+						el.indeterminate = isIndeterminate
+					}
+				}}
 				{...props}
 			/>
 			<span css={[tick, supporting ? tickWithSupportingText : ""]} />
@@ -101,6 +108,7 @@ const checkboxDefaultProps = {
 	type: "checkbox",
 	defaultChecked: false,
 	error: false,
+	isIndeterminate: false,
 }
 
 Checkbox.defaultProps = { ...checkboxDefaultProps }

--- a/packages/checkbox/index.tsx
+++ b/packages/checkbox/index.tsx
@@ -67,25 +67,34 @@ const Checkbox = ({
 	supporting,
 	error,
 	isIndeterminate,
+	defaultChecked,
 	...props
 }: {
 	label: string
 	value: string
 	supporting?: string
 	isIndeterminate: boolean
+	defaultChecked: boolean
 	error: boolean
 }) => {
+	const isChecked = (): boolean | "mixed" => {
+		if (isIndeterminate) return "mixed"
+		return defaultChecked
+	}
+	const setIndeterminate = (el: HTMLInputElement | null): void => {
+		if (el) {
+			el.indeterminate = isIndeterminate
+		}
+	}
 	return (
 		<label css={[label, supporting ? labelWithSupportingText : ""]}>
 			<input
 				css={[checkbox, error ? errorCheckbox : ""]}
 				value={value}
 				aria-invalid={error}
-				ref={el => {
-					if (el) {
-						el.indeterminate = isIndeterminate
-					}
-				}}
+				aria-checked={isChecked()}
+				ref={setIndeterminate}
+				defaultChecked={defaultChecked}
 				{...props}
 			/>
 			<span css={[tick, supporting ? tickWithSupportingText : ""]} />

--- a/packages/checkbox/stories.tsx
+++ b/packages/checkbox/stories.tsx
@@ -79,4 +79,18 @@ errorLight.story = {
 	name: "error light",
 }
 
-export { defaultLight, supportingTextLight, errorLight }
+const indeterminateLight = () => (
+	<CheckboxGroup name="emails">
+		<Checkbox
+			isIndeterminate={true}
+			value="emails-select-all"
+			label="Select all"
+		/>
+	</CheckboxGroup>
+)
+
+indeterminateLight.story = {
+	name: "indeterminate light",
+}
+
+export { defaultLight, supportingTextLight, errorLight, indeterminateLight }

--- a/packages/checkbox/styles.ts
+++ b/packages/checkbox/styles.ts
@@ -45,29 +45,34 @@ export const checkbox = css`
 
 	color: ${palette.border.checkbox};
 
-	&:checked {
-		border: 2px solid ${palette.border.checkboxChecked};
-
-		& ~ span:before {
-			right: 0;
-		}
-		& ~ span:after {
-			top: 0;
-		}
-	}
-
 	&:focus {
 		${focusHalo};
 	}
 
-	/*
-	Take care: Emotion extracts @supports blocks and moves them below
-	all other <style> elements, making these values hard to override.
-	I have chosen to keep these styles in the @supports block as
-	moving them out makes checkboxes look horrible on older browsers
-	*/
 	@supports (appearance: none) {
 		appearance: none;
+		&:checked {
+			border: 2px solid ${palette.border.checkboxChecked};
+
+			& ~ span:before {
+				right: 0;
+			}
+			& ~ span:after {
+				top: 0;
+			}
+		}
+
+		&:indeterminate {
+			&:after {
+				${textSans.xlarge()};
+				color: ${palette.text.secondary};
+				content: "-";
+				position: absolute;
+				top: -10px;
+				left: 5px;
+				z-index: 5;
+			}
+		}
 	}
 `
 

--- a/packages/checkbox/styles.ts
+++ b/packages/checkbox/styles.ts
@@ -68,27 +68,6 @@ export const checkbox = css`
 	*/
 	@supports (appearance: none) {
 		appearance: none;
-
-		&:after {
-			position: absolute;
-			content: "";
-			top: 0;
-			right: 0;
-			bottom: 0;
-			left: 0;
-			transform: scale(0);
-			transform-origin: center;
-			transition: transform ${transitions.short};
-		}
-
-		&:checked {
-			& ~ span:before {
-				right: 0;
-			}
-			& ~ span:after {
-				top: 0;
-			}
-		}
 	}
 `
 


### PR DESCRIPTION
## What is the purpose of this change?

There is a need to support an indeterminate state in checkboxes 

## What does this change?

- Adds indeterminate state styling and story to demonstrate it
- Removes some redundant styling

## Design

### Screenshots

![Screenshot 2019-12-17 at 15 39 07](https://user-images.githubusercontent.com/5931528/71010201-63aa6d80-20e3-11ea-9ce6-b19990f00b06.png)


### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
