### PR TITLE
Radio: better styles, better types, better markup

### DIFF
--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -44,9 +44,9 @@ The direction in which radio buttons are stacked
 
 ### `error`
 
-**`boolean | string`**
+**`string`**
 
-Whether error styling should apply to this group. If a string is passed, this appears as an inline error message
+If passed, error styling should applies to this radio group. The string appears as an inline error message.
 
 ## `Radio` Props
 

--- a/packages/radio/index.tsx
+++ b/packages/radio/index.tsx
@@ -31,18 +31,12 @@ const RadioGroup = ({
 	name: string
 	orientation: Orientation
 	error?: boolean | string
-	children: ReactNode
+	children: JSX.Element | JSX.Element[]
 }) => {
 	return (
 		<div css={[group, orientationStyles[orientation]]} {...props}>
 			{typeof error === "string" && <InlineError>{error}</InlineError>}
 			{React.Children.map(children, child => {
-				if (!React.isValidElement(child)) {
-					// Consumer is probably passing a text node as a child
-					// TODO: Pass error to terminal
-					return <div />
-				}
-
 				return React.cloneElement(
 					child,
 					Object.assign(error ? { error: true } : {}, {

--- a/packages/radio/index.tsx
+++ b/packages/radio/index.tsx
@@ -30,12 +30,12 @@ const RadioGroup = ({
 }: {
 	name: string
 	orientation: Orientation
-	error?: boolean | string
+	error?: string
 	children: JSX.Element | JSX.Element[]
 }) => {
 	return (
 		<div css={[group, orientationStyles[orientation]]} {...props}>
-			{typeof error === "string" && <InlineError>{error}</InlineError>}
+			{error && <InlineError>{error}</InlineError>}
 			{React.Children.map(children, child => {
 				return React.cloneElement(
 					child,
@@ -85,7 +85,7 @@ const Radio = ({
 	label: string
 	value: string
 	supporting?: string
-	error?: boolean
+	error: boolean
 }) => {
 	return (
 		<label
@@ -124,6 +124,7 @@ const radioDefaultProps = {
 	disabled: false,
 	type: "radio",
 	defaultChecked: false,
+	error: false,
 }
 
 Radio.defaultProps = { ...radioDefaultProps }

--- a/packages/radio/index.tsx
+++ b/packages/radio/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from "react"
 import {
-	group,
+	fieldset,
 	label,
 	labelWithSupportingText,
 	radio,
@@ -34,7 +34,7 @@ const RadioGroup = ({
 	children: JSX.Element | JSX.Element[]
 }) => {
 	return (
-		<div css={[group, orientationStyles[orientation]]} {...props}>
+		<fieldset css={[fieldset, orientationStyles[orientation]]} {...props}>
 			{error && <InlineError>{error}</InlineError>}
 			{React.Children.map(children, child => {
 				return React.cloneElement(
@@ -44,7 +44,7 @@ const RadioGroup = ({
 					}),
 				)
 			})}
-		</div>
+		</fieldset>
 	)
 }
 

--- a/packages/radio/stories.tsx
+++ b/packages/radio/stories.tsx
@@ -133,12 +133,12 @@ horizontal.story = {
 	name: "orientation horizontal",
 }
 
-const [errorWithMessageLight, errorWithMessageBlue] = appearances.map(
+const [errorLight, errorBlue] = appearances.map(
 	(appearance: { name: Appearance; theme: {} }) => {
 		const story = () => (
 			<WithBackgroundToggle
 				storyKind="Radio"
-				storyName="error with message"
+				storyName="error"
 				options={appearances.map(a => a.name)}
 				selectedValue={appearance.name}
 			>
@@ -153,7 +153,7 @@ const [errorWithMessageLight, errorWithMessageBlue] = appearances.map(
 		)
 
 		story.story = {
-			name: `error with message ${appearance.name}`,
+			name: `error ${appearance.name}`,
 			parameters: {
 				backgrounds: [
 					Object.assign(
@@ -169,24 +169,12 @@ const [errorWithMessageLight, errorWithMessageBlue] = appearances.map(
 	},
 )
 
-const errorWithoutMessage = () => (
-	<RadioGroup name="colours" error={true}>
-		{unselectedRadios.map((radio, index) =>
-			React.cloneElement(radio, { key: index }),
-		)}
-	</RadioGroup>
-)
-errorWithoutMessage.story = {
-	name: "error without message",
-}
-
 export {
 	verticalLight,
 	verticalBlue,
 	horizontal,
 	supportingTextLight,
 	supportingTextBlue,
-	errorWithMessageLight,
-	errorWithMessageBlue,
-	errorWithoutMessage,
+	errorLight,
+	errorBlue,
 }

--- a/packages/radio/styles.ts
+++ b/packages/radio/styles.ts
@@ -95,7 +95,7 @@ export const labelTextWithSupportingText = css`
 export const supportingText = ({
 	radio,
 }: { radio: RadioTheme } = radioLight) => css`
-	${textSans.medium()};
+	${textSans.small()};
 	color: ${radio.textSupporting};
 `
 

--- a/packages/radio/styles.ts
+++ b/packages/radio/styles.ts
@@ -4,9 +4,10 @@ import { textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
 import { RadioTheme, radioLight } from "@guardian/src-foundations/themes"
 
-export const group = css`
+export const fieldset = css`
 	display: flex;
 	justify-content: flex-start;
+	border: 0;
 `
 
 export const label = ({ radio }: { radio: RadioTheme } = radioLight) => css`


### PR DESCRIPTION
## What is the purpose of this change?

There are a few improvements that were made to checkboxes that could also apply to radio buttons:

- the group could be a fieldset
- the error type could be made more restrictive
- the supporting text could be smaller

## What does this change?

- change the element tag of radio group to fieldset
- make the error type only a string; remove support for message-less errors
- make the supporting text smaller
- restrict children of the radio group to JSX.Element (or arrays of)

## Design


### Screenshots

![Screenshot 2019-12-18 at 10 37 47](https://user-images.githubusercontent.com/5931528/71079071-73c55a00-2182-11ea-8367-11fe8cc44309.png)


### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
