### PR TITLE
Render radio group as div instead of fieldset

### DIFF
--- a/packages/radio/index.tsx
+++ b/packages/radio/index.tsx
@@ -33,8 +33,11 @@ const RadioGroup = ({
 	error?: string
 	children: JSX.Element | JSX.Element[]
 }) => {
+	// TODO: This is currently a div instead of a fieldset due to a Chrome / Safari
+	// bug that prevents flexbox model working on fieldset elements
+	// https://bugs.chromium.org/p/chromium/issues/detail?id=375693
 	return (
-		<fieldset css={[fieldset, orientationStyles[orientation]]} {...props}>
+		<div css={[fieldset, orientationStyles[orientation]]} {...props}>
 			{error && <InlineError>{error}</InlineError>}
 			{React.Children.map(children, child => {
 				return React.cloneElement(
@@ -44,7 +47,7 @@ const RadioGroup = ({
 					}),
 				)
 			})}
-		</fieldset>
+		</div>
 	)
 }
 


### PR DESCRIPTION
## What is the purpose of this change?

The radio groups needs to be rendered as a div instead of a fieldset due to a Chrome / Safari
bug that prevents flexbox model working on fieldset elements

https://bugs.chromium.org/p/chromium/issues/detail?id=375693

## What does this change?

Render radio group as a div

## Design

### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
