### PR TITLE
Support narrow width radio group

### DIFF
--- a/packages/radio/stories.tsx
+++ b/packages/radio/stories.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { css } from "@emotion/core"
 import {
 	storybookBackgrounds,
 	WithBackgroundToggle,
@@ -88,6 +89,10 @@ const [verticalLight, verticalBlue] = appearances.map(
 	},
 )
 
+const narrow = css`
+	width: 30rem;
+`
+
 const [supportingTextLight, supportingTextBlue] = appearances.map(
 	(appearance: { name: Appearance; theme: {} }) => {
 		const story = () => (
@@ -98,11 +103,13 @@ const [supportingTextLight, supportingTextBlue] = appearances.map(
 				selectedValue={appearance.name}
 			>
 				<ThemeProvider theme={appearance.theme}>
-					<RadioGroup name="payment-options">
-						{radiosWithSupportingText.map((radio, index) =>
-							React.cloneElement(radio, { key: index }),
-						)}
-					</RadioGroup>
+					<div css={narrow}>
+						<RadioGroup name="payment-options">
+							{radiosWithSupportingText.map((radio, index) =>
+								React.cloneElement(radio, { key: index }),
+							)}
+						</RadioGroup>
+					</div>
 				</ThemeProvider>
 			</WithBackgroundToggle>
 		)

--- a/packages/radio/styles.ts
+++ b/packages/radio/styles.ts
@@ -29,6 +29,7 @@ export const labelWithSupportingText = css`
 `
 
 export const radio = ({ radio }: { radio: RadioTheme } = radioLight) => css`
+	flex: 0 0 auto;
 	cursor: pointer;
 	box-sizing: border-box;
 	display: inline-block;


### PR DESCRIPTION
## What is the purpose of this change?

If the radio group width is narrowed, the radio button gets squashed proportionally

## What does this change?

Setting `flex: 0 0 auto` allows the radio button to expand to the width it needs to be
