### PR TITLE
Checkbox: rich supporting content

### DIFF
--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -25,7 +25,11 @@ const Form = () => (
             <Checkbox
                 value="today-us"
                 label="Guardian Today: US"
-                supporting="Cut through the noise. Get straight to the heart of the day’s breaking news in double-quick time."
+                supporting={
+                    <>
+                        <strong>Cut through the noise.</strong> Get straight to the heart of the day’s breaking news in double-quick time.
+                    </>
+                }
             />
         </CheckboxGroup>
     </form>
@@ -56,9 +60,9 @@ Appears to the right of the checkbox
 
 ### `supporting`
 
-**`string`**
+**`ReactNode`**
 
-Additional text that appears below the label
+Additional text or a component that appears below the label
 
 ### `isIndeterminate`
 

--- a/packages/checkbox/index.tsx
+++ b/packages/checkbox/index.tsx
@@ -72,7 +72,7 @@ const Checkbox = ({
 }: {
 	label: string
 	value: string
-	supporting?: string
+	supporting?: ReactNode
 	isIndeterminate: boolean
 	defaultChecked: boolean
 	error: boolean

--- a/packages/checkbox/stories.tsx
+++ b/packages/checkbox/stories.tsx
@@ -28,7 +28,11 @@ const checkboxesWithSupportingText = [
 	<Checkbox
 		value="events"
 		label="Events & Masterclasses"
-		supporting="Learn from leading minds at our Guardian live events, including discussions and debates, courses and training"
+		supporting={
+			<>
+			Learn from leading minds at our <a href="https://membership.theguardian.com/events">Guardian live events</a>, including discussions and debates, courses and training
+			</>
+		}
 	/>,
 ]
 /* eslint-enable react/jsx-key */

--- a/packages/checkbox/stories.tsx
+++ b/packages/checkbox/stories.tsx
@@ -30,7 +30,9 @@ const checkboxesWithSupportingText = [
 		label="Events & Masterclasses"
 		supporting={
 			<>
-			Learn from leading minds at our <a href="https://membership.theguardian.com/events">Guardian live events</a>, including discussions and debates, courses and training
+				Learn from leading minds at our{" "}
+				<strong>Guardian live events</strong>, including discussions and
+				debates, courses and training
 			</>
 		}
 	/>,


### PR DESCRIPTION
## What is the purpose of this change?

It is necessary to add more than simple text to the "supporting" section of the checkbox label. We should be able to display rich content here too.

## What does this change?

Updates the expected type of the `supporting` prop to `ReactNode`

## Design

### Screenshots

![Screenshot 2019-12-19 at 11 20 50](https://user-images.githubusercontent.com/5931528/71169770-a1c59f80-2251-11ea-8b2b-bb76cbc5d659.png)

### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
