### PR TITLE
Radio: rich supporting content

### DIFF
--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -58,6 +58,6 @@ Appears to the right of the radio button
 
 ### `supporting`
 
-**`string`**
+**`ReactNode`**
 
-Additional text that appears below the label
+Additional text or a component that appears below the label

--- a/packages/radio/index.tsx
+++ b/packages/radio/index.tsx
@@ -87,7 +87,7 @@ const Radio = ({
 }: {
 	label: string
 	value: string
-	supporting?: string
+	supporting?: ReactNode
 	error: boolean
 }) => {
 	return (

--- a/packages/radio/stories.tsx
+++ b/packages/radio/stories.tsx
@@ -29,7 +29,12 @@ const radiosWithSupportingText = [
 	<Radio
 		value="annual"
 		label="Annual"
-		supporting="Subscribe for 12 months and save 10% £135 for 1 year then standard rate (£150 every year)"
+		supporting={
+			<>
+				Subscribe for <strong>12 months</strong> and save 10% £135 for 1
+				year then standard rate (£150 every year)
+			</>
+		}
 	/>,
 ]
 const unselectedRadios = [


### PR DESCRIPTION
## What is the purpose of this change?

It is necessary to add more than simple text to the "supporting" section of the radio label. We should be able to display rich content here too.

## What does this change?

Updates the expected type of the `supporting` prop to `ReactNode`

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

![Screenshot 2019-12-19 at 11 32 43](https://user-images.githubusercontent.com/5931528/71170478-4a283380-2253-11ea-951d-3f0c7458faa9.png)

### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
