### PR TITLE
Checkbox: presentational improvements

### DIFF
--- a/packages/checkbox/index.tsx
+++ b/packages/checkbox/index.tsx
@@ -70,7 +70,7 @@ const Checkbox = ({
 	defaultChecked,
 	...props
 }: {
-	label: string
+	label: ReactNode
 	value: string
 	supporting?: ReactNode
 	isIndeterminate: boolean

--- a/packages/checkbox/styles.ts
+++ b/packages/checkbox/styles.ts
@@ -38,7 +38,7 @@ export const checkbox = css`
 	cursor: pointer;
 	width: ${size.small}px;
 	height: ${size.small}px;
-	margin: 0 ${space[1]}px 0 0;
+	margin: 0 ${space[2]}px 0 0;
 
 	border: 2px solid currentColor;
 	position: relative;

--- a/packages/checkbox/styles.ts
+++ b/packages/checkbox/styles.ts
@@ -8,6 +8,8 @@ export const fieldset = css`
 	justify-content: flex-start;
 	flex-direction: column;
 	border: 0;
+	padding: 0;
+	margin: 0;
 `
 
 export const label = css`


### PR DESCRIPTION
## What is the purpose of this change?

- User agent spacing for fieldsets can be a bit loose
- Spacing between checkbox and label is very tight
- The checkbox label is not very flexible when defined as a string. What if a label needed some rich text?

## What does this change?

- Increase spacing between checkbox and label
- Reset user agent styling for fieldset
- allow checkbox label to receive a `ReactNode`

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

**Before**

![Screenshot 2020-01-02 at 11 45 01](https://user-images.githubusercontent.com/5931528/71665568-65b43380-2d55-11ea-99d7-f40121351f8e.png)

**After**

![Screenshot 2020-01-02 at 11 45 30](https://user-images.githubusercontent.com/5931528/71665569-65b43380-2d55-11ea-957b-ebbfc773c106.png)


### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
