### PR TITLE
Radio: label to support rich content

### DIFF
--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -52,7 +52,7 @@ If passed, error styling should applies to this radio group. The string appears 
 
 ### `label`
 
-**`string`**
+**`ReactNode`**
 
 Appears to the right of the radio button
 

--- a/packages/radio/index.tsx
+++ b/packages/radio/index.tsx
@@ -85,7 +85,7 @@ const Radio = ({
 	error,
 	...props
 }: {
-	label: string
+	label: ReactNode
 	value: string
 	supporting?: ReactNode
 	error: boolean

--- a/packages/radio/styles.ts
+++ b/packages/radio/styles.ts
@@ -35,7 +35,7 @@ export const radio = ({ radio }: { radio: RadioTheme } = radioLight) => css`
 	display: inline-block;
 	width: ${size.small}px;
 	height: ${size.small}px;
-	margin: 0 ${space[1]}px 0 0;
+	margin: 0 ${space[2]}px 0 0;
 
 	border: 2px solid currentColor;
 	border-radius: 50%;


### PR DESCRIPTION
## What is the purpose of this change?

- Spacing between radio and label is very tight
- The radio label is not very flexible when defined as a string. What if a label needed some rich text?

## What does this change?

- Increase spacing between radio and label
- allow radio label to receive a `ReactNode`

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

**Before**
![Screenshot 2020-01-02 at 11 50 53](https://user-images.githubusercontent.com/5931528/71665816-2b976180-2d56-11ea-913c-57e0b57a809d.png)

**After**

![Screenshot 2020-01-02 at 11 50 58](https://user-images.githubusercontent.com/5931528/71665817-2c2ff800-2d56-11ea-9a13-a50bcf812877.png)

### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
