### PR TITLE
Loosen up radio button spacing

### DIFF
--- a/packages/radio/stories.tsx
+++ b/packages/radio/stories.tsx
@@ -21,12 +21,6 @@ const radiosWithSupportingText = [
 		supporting="£6 for the first 6 issues (then £37.50 every quarter)"
 	/>,
 	<Radio
-		value="quarterly"
-		label="Quarterly"
-		supporting="£37.50 every quarter"
-		defaultChecked
-	/>,
-	<Radio
 		value="annual"
 		label="Annual"
 		supporting={
@@ -35,6 +29,12 @@ const radiosWithSupportingText = [
 				year then standard rate (£150 every year)
 			</>
 		}
+	/>,
+	<Radio
+		value="quarterly"
+		label="Quarterly"
+		supporting="£37.50 every quarter"
+		defaultChecked
 	/>,
 ]
 const unselectedRadios = [

--- a/packages/radio/styles.ts
+++ b/packages/radio/styles.ts
@@ -14,7 +14,7 @@ export const label = ({ radio }: { radio: RadioTheme } = radioLight) => css`
 	cursor: pointer;
 	display: flex;
 	align-items: center;
-	height: ${size.large}px;
+	min-height: ${size.large}px;
 
 	&:hover {
 		input {
@@ -25,7 +25,7 @@ export const label = ({ radio }: { radio: RadioTheme } = radioLight) => css`
 
 export const labelWithSupportingText = css`
 	align-items: flex-start;
-	margin-bottom: ${space[2]}px;
+	margin-bottom: ${space[5]}px;
 `
 
 export const radio = ({ radio }: { radio: RadioTheme } = radioLight) => css`
@@ -96,7 +96,7 @@ export const labelTextWithSupportingText = css`
 export const supportingText = ({
 	radio,
 }: { radio: RadioTheme } = radioLight) => css`
-	${textSans.small()};
+	${textSans.small({ lineHeight: "regular" })};
 	color: ${radio.textSupporting};
 `
 
@@ -104,7 +104,7 @@ export const horizontal = css`
 	flex-direction: row;
 
 	label {
-		margin-right: ${space[2]}px;
+		margin-right: ${space[5]}px;
 	}
 `
 export const vertical = css`


### PR DESCRIPTION
## What is the purpose of this change?

Radio button spacing is a bit disjointed. 

## What does this change?

- increases spacing between items with supporting text
- increases spacing between horizontally-oriented buttons
- tightens line-height of supporting text

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

**Before**

Horizontal:

![Screenshot 2020-01-02 at 12 42 10](https://user-images.githubusercontent.com/5931528/71667512-53d68e80-2d5d-11ea-99b9-05859e0764bf.png)

Supporting:

![Screenshot 2020-01-02 at 12 42 15](https://user-images.githubusercontent.com/5931528/71667513-53d68e80-2d5d-11ea-8c20-43d5f71094df.png)

**After**

Horizontal:

![Screenshot 2020-01-02 at 12 41 54](https://user-images.githubusercontent.com/5931528/71667520-5933d900-2d5d-11ea-8b46-0ec273064cdc.png)

Supporting:

![Screenshot 2020-01-02 at 12 42 01](https://user-images.githubusercontent.com/5931528/71667521-5933d900-2d5d-11ea-86e3-ce8ad502daed.png)


### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
