### PR TITLE
Tighten line-height of checkbox supporting text

### DIFF
--- a/packages/checkbox/styles.ts
+++ b/packages/checkbox/styles.ts
@@ -88,7 +88,7 @@ export const labelTextWithSupportingText = css`
 `
 
 export const supportingText = css`
-	${textSans.small()};
+	${textSans.small({ lineHeight: "regular" })};
 	color: ${palette.text.secondary};
 `
 


### PR DESCRIPTION
## What is the purpose of this change?

Supporting text feels disjointed

## What does this change?

Tighten the line-height to bring it back into equilibrium. It's a small change, but it checks out

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

**Before**

![Screenshot 2020-01-02 at 13 32 57](https://user-images.githubusercontent.com/5931528/71669398-6f916300-2d64-11ea-9b15-bf980317d74d.png)

**After**

![Screenshot 2020-01-02 at 13 36 20](https://user-images.githubusercontent.com/5931528/71669549-e595ca00-2d64-11ea-9d4b-821f8ad7770b.png)

### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
