### PR TITLE
Checkbox: better state manipulation

### DIFF
--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -20,7 +20,7 @@ const Form = () => (
                 value="today-uk"
                 label="Guardian Today: UK"
                 supporting="The headlines, the analysis, the debate. Get the whole picture from a source you trust."
-                defaultChecked
+                checked={true}
             />
             <Checkbox
                 value="today-us"
@@ -66,7 +66,13 @@ Appears to the right of the checkbox
 
 Additional text or a component that appears below the label
 
-### `isIndeterminate`
+### `checked`
+
+**`boolean`**
+
+Whether checkbox is checked
+
+### `indeterminate`
 
 **`boolean`**
 

--- a/packages/checkbox/index.tsx
+++ b/packages/checkbox/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react"
+import React, { ReactNode, ChangeEvent } from "react"
 import {
 	fieldset,
 	label,
@@ -64,26 +64,28 @@ const SupportingText = ({ children }: { children: ReactNode }) => {
 const Checkbox = ({
 	label: labelContent,
 	value,
+	checked,
 	supporting,
 	error,
-	isIndeterminate,
-	defaultChecked,
+	indeterminate,
 	...props
 }: {
 	label: ReactNode
 	value: string
+	checked: boolean
 	supporting?: ReactNode
-	isIndeterminate: boolean
-	defaultChecked: boolean
+	indeterminate: boolean
 	error: boolean
+	onChange?: (event: ChangeEvent<HTMLInputElement>) => void
 }) => {
 	const isChecked = (): boolean | "mixed" => {
-		if (isIndeterminate) return "mixed"
-		return defaultChecked
+		if (indeterminate) return "mixed"
+		return checked
 	}
-	const setIndeterminate = (el: HTMLInputElement | null): void => {
+	const setCheckboxState = (el: HTMLInputElement | null): void => {
 		if (el) {
-			el.indeterminate = isIndeterminate
+			el.indeterminate = indeterminate
+			el.checked = checked
 		}
 	}
 	return (
@@ -93,8 +95,7 @@ const Checkbox = ({
 				value={value}
 				aria-invalid={error}
 				aria-checked={isChecked()}
-				ref={setIndeterminate}
-				defaultChecked={defaultChecked}
+				ref={setCheckboxState}
 				{...props}
 			/>
 			<span css={[tick, supporting ? tickWithSupportingText : ""]} />
@@ -115,9 +116,9 @@ const Checkbox = ({
 const checkboxDefaultProps = {
 	disabled: false,
 	type: "checkbox",
-	defaultChecked: false,
+	checked: false,
 	error: false,
-	isIndeterminate: false,
+	indeterminate: false,
 }
 
 Checkbox.defaultProps = { ...checkboxDefaultProps }

--- a/packages/checkbox/index.tsx
+++ b/packages/checkbox/index.tsx
@@ -66,26 +66,38 @@ const Checkbox = ({
 	value,
 	checked,
 	supporting,
+	defaultChecked,
 	error,
 	indeterminate,
 	...props
 }: {
 	label: ReactNode
 	value: string
-	checked: boolean
+	checked?: boolean
 	supporting?: ReactNode
+	defaultChecked: boolean
 	indeterminate: boolean
 	error: boolean
 	onChange?: (event: ChangeEvent<HTMLInputElement>) => void
 }) => {
 	const isChecked = (): boolean | "mixed" => {
-		if (indeterminate) return "mixed"
-		return checked
+		// Note: the indeterminate prop takes precedence over the checked prop
+		if (indeterminate) {
+			return "mixed"
+		}
+
+		if (checked != null) {
+			return checked
+		}
+
+		return defaultChecked
 	}
 	const setCheckboxState = (el: HTMLInputElement | null): void => {
 		if (el) {
 			el.indeterminate = indeterminate
-			el.checked = checked
+			if (checked != null) {
+				el.checked = checked
+			}
 		}
 	}
 	return (
@@ -117,7 +129,6 @@ const checkboxDefaultProps = {
 	disabled: false,
 	type: "checkbox",
 	defaultChecked: false,
-	checked: false,
 	indeterminate: false,
 	error: false,
 }

--- a/packages/checkbox/index.tsx
+++ b/packages/checkbox/index.tsx
@@ -116,9 +116,10 @@ const Checkbox = ({
 const checkboxDefaultProps = {
 	disabled: false,
 	type: "checkbox",
+	defaultChecked: false,
 	checked: false,
-	error: false,
 	indeterminate: false,
+	error: false,
 }
 
 Checkbox.defaultProps = { ...checkboxDefaultProps }

--- a/packages/checkbox/stories.tsx
+++ b/packages/checkbox/stories.tsx
@@ -23,7 +23,7 @@ const checkboxesWithSupportingText = [
 		value="holidays"
 		label="Holidays & Vacations"
 		supporting="Ideas and inspiration for your next trip away, as well as the latest offers from Guardian Holidays"
-		defaultChecked
+		checked={true}
 	/>,
 	<Checkbox
 		value="events"
@@ -86,13 +86,11 @@ errorLight.story = {
 }
 
 const indeterminateLight = () => (
-	<CheckboxGroup name="emails">
-		<Checkbox
-			isIndeterminate={true}
-			value="emails-select-all"
-			label="Select all"
-		/>
-	</CheckboxGroup>
+	<Checkbox
+		indeterminate={true}
+		value="indeterminate"
+		label="Indeterminate"
+	/>
 )
 
 indeterminateLight.story = {


### PR DESCRIPTION
## What is the purpose of this change?

- There is no way to programmatically update the checkbox state
- The `isIndeterminate` prop is a bit "uncanny valley" (is inconsistent with DOM API's `indeterminate` property)

## What does this change?

- Adds a `checked` prop that sets the checkbox's using a React ref
- Updates the `isIndeterminate` prop to `indeterminate` for consistency
- `indeterminate` takes precendence over `checked`, which takes precendence over `defaultChecked`