### PR TITLE
Support programmatically checking radio buttons

### DIFF
--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -20,7 +20,7 @@ const Form = () => (
                 value="no"
                 label="No"
                 supporting="I do not accept the terms"
-                defaultChecked
+                checked={true}
             />
             <Radio value="yes" label="Yes" supporting="I accept the terms" />,
         </RadioGroup>
@@ -61,3 +61,9 @@ Appears to the right of the radio button
 **`ReactNode`**
 
 Additional text or a component that appears below the label
+
+### `checked`
+
+**`boolean`**
+
+Whether radio button is checked

--- a/packages/radio/index.tsx
+++ b/packages/radio/index.tsx
@@ -82,14 +82,22 @@ const Radio = ({
 	label: labelContent,
 	value,
 	supporting,
+	checked,
 	error,
 	...props
 }: {
 	label: ReactNode
 	value: string
 	supporting?: ReactNode
+	checked?: boolean
 	error: boolean
 }) => {
+	const setRadioState = (el: HTMLInputElement | null) => {
+		if (el && checked != null) {
+			el.checked = checked
+		}
+	}
+
 	return (
 		<label
 			css={theme => [
@@ -104,6 +112,7 @@ const Radio = ({
 				]}
 				value={value}
 				aria-invalid={error}
+				ref={setRadioState}
 				{...props}
 			/>
 			{supporting ? (

--- a/packages/radio/stories.tsx
+++ b/packages/radio/stories.tsx
@@ -11,7 +11,7 @@ import { ThemeProvider } from "emotion-theming"
 /* eslint-disable react/jsx-key */
 const radios = [
 	<Radio value="red" label="Red" />,
-	<Radio value="green" label="Green" defaultChecked />,
+	<Radio value="green" label="Green" checked={true} />,
 	<Radio value="blue" label="Blue" />,
 ]
 const radiosWithSupportingText = [
@@ -24,7 +24,7 @@ const radiosWithSupportingText = [
 		value="quarterly"
 		label="Quarterly"
 		supporting="£37.50 every quarter"
-		defaultChecked
+		checked={true}
 	/>,
 	<Radio
 		value="annual"
@@ -138,7 +138,7 @@ const [supportingTextLight, supportingTextBlue] = appearances.map(
 const horizontal = () => (
 	<RadioGroup orientation="horizontal" name="yes-or-no">
 		<Radio value="yes" label="Yes" />
-		<Radio value="no" label="No" defaultChecked />
+		<Radio value="no" label="No" checked={true} />
 	</RadioGroup>
 )
 horizontal.story = {


### PR DESCRIPTION
## What is the purpose of this change?

There is no way to programmatically update the radio button state

## What does this change?

Adds a `checked` prop that sets the radio button's checked state using a React ref. This takes precedence over the `defaultChecked` prop