### PR TITLE
Add missing prop types to text-input

### DIFF
--- a/packages/text-input/index.tsx
+++ b/packages/text-input/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react"
+import React, { ReactNode, ChangeEvent } from "react"
 import { InlineError } from "@guardian/src-inline-error"
 import {
 	widthFluid,
@@ -41,6 +41,8 @@ const TextInput = ({
 	supporting?: string
 	width?: Width
 	error?: string
+	value?: string
+	onChange?: (event: ChangeEvent<HTMLInputElement>) => void
 }) => {
 	return (
 		<label>


### PR DESCRIPTION
## What is the purpose of this change?

There a couple of missing types that would be useful for consumers of text-input

## What does this change?

Adds the following optional props:

- value: string
- onChange: (Event) => void
