### PR TITLE
Add type for tab index

### DIFF
--- a/packages/button/index.tsx
+++ b/packages/button/index.tsx
@@ -72,8 +72,9 @@ const Button = ({
 }: {
 	priority: Priority
 	size: Size
-	icon?: ReactElement
 	iconSide: IconSide
+	icon?: ReactElement
+	tabIndex?: number
 	onClick?: () => void
 	children?: ReactNode
 }) => {


### PR DESCRIPTION
## What is the purpose of this change?

Buttons may accept a tab index, allowing a consumer to specify the order in which elements on the page receive focus.

## What does this change?

The tab index is already passed from the `<Button>` component to the `<button>` element, so this PR just tells the TypeScript compiler to expect this prop.

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
