### PR TITLE
Remove background toggle from inline-error stories

### DIFF
--- a/packages/inline-error/stories.tsx
+++ b/packages/inline-error/stories.tsx
@@ -5,11 +5,7 @@ import {
 	inlineErrorLight,
 	inlineErrorBrand,
 } from "@guardian/src-foundations/themes"
-import {
-	Appearance,
-	WithBackgroundToggle,
-	storybookBackgrounds,
-} from "@guardian/src-helpers"
+import { Appearance, storybookBackgrounds } from "@guardian/src-helpers"
 import { InlineError } from "./index"
 
 export default {
@@ -33,16 +29,9 @@ const [defaultLight, defaultBlue] = appearances.map(
 		theme: { inlineError: InlineErrorTheme }
 	}) => {
 		const story = () => (
-			<WithBackgroundToggle
-				storyKind="InlineError"
-				storyName="default"
-				options={appearances.map(a => a.name)}
-				selectedValue={appearance.name}
-			>
-				<ThemeProvider theme={appearance.theme}>
-					<InlineError>Please enter your name</InlineError>
-				</ThemeProvider>
-			</WithBackgroundToggle>
+			<ThemeProvider theme={appearance.theme}>
+				<InlineError>Please enter your name</InlineError>
+			</ThemeProvider>
 		)
 
 		story.story = {


### PR DESCRIPTION
## What is the purpose of this change?

Arguably using the background toggle for navigation hides the different themes that can be applied to this component. We should prefer stacking the stories for different themes in Zeroheight instead. 

## What does this change?

Removes background toggle from stories
