### PR TITLE
Add icon styling to links

### DIFF
--- a/packages/link/index.tsx
+++ b/packages/link/index.tsx
@@ -40,7 +40,11 @@ const Link = ({
 	const linkContents = [children]
 
 	if (iconSvg) {
-		linkContents.push(React.cloneElement(iconSvg, { key: "svg" }))
+		if (iconSide === "left") {
+			linkContents.unshift(React.cloneElement(iconSvg, { key: "svg" }))
+		} else {
+			linkContents.push(React.cloneElement(iconSvg, { key: "svg" }))
+		}
 	}
 	return (
 		<a

--- a/packages/link/index.tsx
+++ b/packages/link/index.tsx
@@ -38,12 +38,20 @@ const Link = ({
 	children?: ReactNode
 }) => {
 	const linkContents = [children]
+	// a bit of underlined space; the icon sits on top
+	const spacer = <>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</>
 
 	if (iconSvg) {
 		if (iconSide === "left") {
-			linkContents.unshift(React.cloneElement(iconSvg, { key: "svg" }))
+			linkContents.unshift(
+				React.cloneElement(iconSvg, { key: "svg" }),
+				spacer,
+			)
 		} else {
-			linkContents.push(React.cloneElement(iconSvg, { key: "svg" }))
+			linkContents.push(
+				React.cloneElement(iconSvg, { key: "svg" }),
+				spacer,
+			)
 		}
 	}
 	return (

--- a/packages/link/stories.tsx
+++ b/packages/link/stories.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { css } from "@emotion/core"
 import { storybookBackgrounds } from "@guardian/src-helpers"
-import { SvgCheckmark } from "@guardian/src-svgs"
+import { SvgCheckmark, SvgArrowRightStraight } from "@guardian/src-svgs"
 import { size } from "@guardian/src-foundations"
 import { Link, linkLight, linkBrandYellow, linkBrand } from "./index"
 import { ThemeProvider } from "emotion-theming"
@@ -15,7 +15,7 @@ const priorityLinks = [
 ]
 
 const textIconLinks = [
-	<Link icon={<SvgCheckmark />} href="#">
+	<Link icon={<SvgArrowRightStraight />} href="#">
 		Icon to the left
 	</Link>,
 	<Link iconSide="right" icon={<SvgCheckmark />} href="#">

--- a/packages/link/stories.tsx
+++ b/packages/link/stories.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { css } from "@emotion/core"
 import { storybookBackgrounds } from "@guardian/src-helpers"
-// import { SvgCheckmark } from "@guardian/src-svgs"
+import { SvgCheckmark } from "@guardian/src-svgs"
 import { size } from "@guardian/src-foundations"
 import { Link, linkLight, linkBrandYellow, linkBrand } from "./index"
 import { ThemeProvider } from "emotion-theming"
@@ -14,15 +14,14 @@ const priorityLinks = [
 	</Link>,
 ]
 
-// TODO: make icon support better!
-// const textIconLinks = [
-// 	<Link icon={<SvgCheckmark />} href="#">
-// 		Icon to the left
-// 	</Link>,
-// 	<Link iconSide="right" icon={<SvgCheckmark />} href="#">
-// 		Icon to the right
-// 	</Link>,
-// ]
+const textIconLinks = [
+	<Link icon={<SvgCheckmark />} href="#">
+		Icon to the left
+	</Link>,
+	<Link iconSide="right" icon={<SvgCheckmark />} href="#">
+		Icon to the right
+	</Link>,
+]
 /* eslint-enable react/jsx-key */
 
 const flexStart = css`
@@ -87,14 +86,13 @@ priorityYellow.story = {
 	},
 }
 
-// TODO: make icon support better!
-// export const textAndIcon = () => (
-// 	<div css={flexStart}>
-// 		{textIconLinks.map((button, index) => (
-// 			<div key={index}>{button}</div>
-// 		))}
-// 	</div>
-// )
-// textAndIcon.story = {
-// 	name: "text and icon",
-// }
+export const textAndIcon = () => (
+	<div css={flexStart}>
+		{textIconLinks.map((button, index) => (
+			<div key={index}>{button}</div>
+		))}
+	</div>
+)
+textAndIcon.story = {
+	name: "text and icon",
+}

--- a/packages/link/styles.ts
+++ b/packages/link/styles.ts
@@ -1,5 +1,5 @@
 import { css } from "@emotion/core"
-import { size } from "@guardian/src-foundations"
+import { space } from "@guardian/src-foundations"
 import { linkLight, LinkTheme } from "@guardian/src-foundations/themes"
 import { textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
@@ -30,25 +30,24 @@ export const secondary = ({ link }: { link: LinkTheme } = linkLight) => css`
 `
 
 export const icon = css`
+	border-bottom: 1px solid currentColor;
+	text-decoration: none;
 	svg {
-		flex: 0 0 auto;
-		display: block;
 		fill: currentColor;
 		position: relative;
-		width: ${size.large / 2}px;
-		height: auto;
+		width: auto;
+		height: 17px;
 	}
 `
 
 export const iconRight = css`
 	svg {
-		margin: 0 ${-size.large / 8}px 0 ${size.large / 4}px;
+		margin-left: ${space[1]}px;
 	}
 `
 
 export const iconLeft = css`
-	flex-direction: row-reverse;
 	svg {
-		margin: 0 ${size.large / 4}px 0 ${-size.large / 8}px;
+		margin-right: ${space[1]}px;
 	}
 `

--- a/packages/link/styles.ts
+++ b/packages/link/styles.ts
@@ -1,10 +1,10 @@
 import { css } from "@emotion/core"
-import { space } from "@guardian/src-foundations"
 import { linkLight, LinkTheme } from "@guardian/src-foundations/themes"
-import { textSans } from "@guardian/src-foundations/typography"
+import { textSans, textSansSizes } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
 
 export const link = css`
+	position: relative;
 	${textSans.medium()};
 	cursor: pointer;
 
@@ -30,24 +30,25 @@ export const secondary = ({ link }: { link: LinkTheme } = linkLight) => css`
 `
 
 export const icon = css`
-	border-bottom: 1px solid currentColor;
-	text-decoration: none;
 	svg {
 		fill: currentColor;
-		position: relative;
+		position: absolute;
+		height: ${textSansSizes.medium}rem;
 		width: auto;
-		height: 17px;
+
+		/* magic number to align the SVG to the text baseline*/
+		bottom: 3px;
 	}
 `
 
 export const iconRight = css`
 	svg {
-		margin-left: ${space[1]}px;
+		right: 0;
 	}
 `
 
 export const iconLeft = css`
 	svg {
-		margin-right: ${space[1]}px;
+		left: 0;
 	}
 `


### PR DESCRIPTION
## What is the purpose of this change?

The design system allows us to add icons to links.

## What does this change?

Adds styling to handle icons passed as a prop to a Link component. 

Because `text-decoration` does not apply to SVGs, the underline is achieved by adding a spacer (a series of `&nbsp;` entities) to the beginning or end of a link and positioning the SVG on top.

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

![Screenshot 2020-01-09 at 12 01 51](https://user-images.githubusercontent.com/5931528/72066197-e46e1b00-32d7-11ea-8a07-820de0c622dc.png)

### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
