### PR TITLE
Add subdued link API

### DIFF
--- a/packages/link/README.md
+++ b/packages/link/README.md
@@ -17,6 +17,7 @@ import { SvgArrowRightStraight } from "@guardian/src-svgs"
 const Navigation = () => (
     <Link
         priority="primary"
+        subdued={true}
         icon={<SvgArrowRightStraight />}
         iconSide="right"
         href="/read-more"
@@ -33,6 +34,12 @@ const Navigation = () => (
 **`"primary" | "secondary"`** _= "primary"_
 
 Informs users of how important a link is
+
+### `subdued`
+
+**`boolean`** _= false_
+
+Whether link is subdued (no underline)
 
 ### `icon`
 

--- a/packages/link/index.tsx
+++ b/packages/link/index.tsx
@@ -1,5 +1,13 @@
 import React, { ReactElement, ReactNode } from "react"
-import { link, primary, secondary, icon, iconRight, iconLeft } from "./styles"
+import {
+	link,
+	primary,
+	secondary,
+	subdued,
+	icon,
+	iconRight,
+	iconLeft,
+} from "./styles"
 import { SerializedStyles } from "@emotion/css"
 import { LinkTheme } from "@guardian/src-foundations/themes"
 export {
@@ -26,12 +34,14 @@ const iconSides: {
 }
 const Link = ({
 	priority,
+	subdued: isSubdued,
 	icon: iconSvg,
 	iconSide,
 	children,
 	...props
 }: {
 	priority: Priority
+	subdued: boolean
 	icon?: ReactElement
 	iconSide: IconSide
 	href: string
@@ -59,6 +69,7 @@ const Link = ({
 			css={theme => [
 				link,
 				priorities[priority](theme.link && theme),
+				isSubdued ? subdued : "",
 				iconSvg ? icon : "",
 				iconSvg ? iconSides[iconSide] : "",
 			]}
@@ -71,6 +82,7 @@ const Link = ({
 
 const defaultLinkProps = {
 	priority: "primary",
+	subdued: false,
 	iconSide: "left",
 }
 

--- a/packages/link/stories.tsx
+++ b/packages/link/stories.tsx
@@ -17,6 +17,14 @@ const priorityLinks = [
 		Secondary
 	</Link>,
 ]
+const subduedLinks = [
+	<Link subdued={true} href="#">
+		Primary subdued
+	</Link>,
+	<Link subdued={true} priority="secondary" href="#">
+		Secondary subdued
+	</Link>,
+]
 /* eslint-enable react/jsx-key */
 
 const flexStart = css`
@@ -84,6 +92,17 @@ priorityYellow.story = {
 const spacer = css`
 	margin-bottom: 1rem;
 `
+
+export const subduedLight = () => (
+	<ThemeProvider theme={linkLight}>
+		<div css={flexStart}>
+			{subduedLinks.map((button, index) => (
+				<div key={index}>{button}</div>
+			))}
+		</div>
+	</ThemeProvider>
+)
+subduedLight.story = { name: "subdued light" }
 
 export const textAndIcon = () => (
 	<>

--- a/packages/link/styles.ts
+++ b/packages/link/styles.ts
@@ -29,6 +29,14 @@ export const secondary = ({ link }: { link: LinkTheme } = linkLight) => css`
 	}
 `
 
+export const subdued = css`
+	text-decoration: none;
+
+	&:hover {
+		text-decoration: underline;
+	}
+`
+
 export const icon = css`
 	svg {
 		fill: currentColor;


### PR DESCRIPTION
## What is the purpose of this change?

It should be possible for a link to appear subdued (with no underline), to reduce the visual loudness of the link

## What does this change?

Adds a `subdued` prop (default to `false`) that sets `text-decoration: none` when `true`

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

![Screenshot 2020-01-09 at 15 44 09](https://user-images.githubusercontent.com/5931528/72081732-e4c9de80-32f6-11ea-8973-971f6d150f51.png)


### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
