### PR TITLE
Inline Reader Revenue themes for button

### DIFF
--- a/packages/button/index.tsx
+++ b/packages/button/index.tsx
@@ -18,12 +18,12 @@ import { SerializedStyles } from "@emotion/css"
 import { ButtonTheme } from "@guardian/src-foundations/themes"
 import { SvgArrowRightStraight } from "@guardian/src-svgs"
 export {
+	ButtonTheme,
 	buttonLight,
 	buttonBrand,
 	buttonBrandYellow,
-	buttonReaderRevenue,
-	buttonReaderRevenueYellow,
 } from "@guardian/src-foundations/themes"
+export { buttonReaderRevenue, buttonReaderRevenueYellow } from "./themes"
 
 export type Priority = "primary" | "secondary" | "tertiary"
 type IconSide = "left" | "right"

--- a/packages/button/index.tsx
+++ b/packages/button/index.tsx
@@ -18,7 +18,6 @@ import { SerializedStyles } from "@emotion/css"
 import { ButtonTheme } from "@guardian/src-foundations/themes"
 import { SvgArrowRightStraight } from "@guardian/src-svgs"
 export {
-	ButtonTheme,
 	buttonLight,
 	buttonBrand,
 	buttonBrandYellow,

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -25,7 +25,8 @@
 	"files": [
 		"dist/*.js",
 		"index.tsx",
-		"styles.ts"
+		"styles.ts",
+		"themes.ts"
 	],
 	"peerDependencies": {
 		"@emotion/core": "^10.0.14",

--- a/packages/button/stories.tsx
+++ b/packages/button/stories.tsx
@@ -132,11 +132,7 @@ priorityReaderRevenueBlue.story = {
 	name: "priority reader revenue blue",
 	parameters: {
 		backgrounds: [
-			Object.assign(
-				{},
-				{ default: true },
-				storybookBackgrounds["reader revenue blue"],
-			),
+			Object.assign({}, { default: true }, storybookBackgrounds.blue),
 		],
 	},
 }
@@ -154,11 +150,7 @@ priorityReaderRevenueYellow.story = {
 	name: "priority reader revenue yellow",
 	parameters: {
 		backgrounds: [
-			Object.assign(
-				{},
-				{ default: true },
-				storybookBackgrounds["reader revenue yellow"],
-			),
+			Object.assign({}, { default: true }, storybookBackgrounds.yellow),
 		],
 	},
 }

--- a/packages/button/themes.ts
+++ b/packages/button/themes.ts
@@ -1,5 +1,5 @@
 import { palette } from "@guardian/src-foundations"
-import { ButtonTheme } from "./index"
+import { ButtonTheme } from "@guardian/src-foundations/themes"
 
 export const buttonReaderRevenue: { button: ButtonTheme } = {
 	button: {

--- a/packages/button/themes.ts
+++ b/packages/button/themes.ts
@@ -1,0 +1,31 @@
+import { palette } from "@guardian/src-foundations"
+import { ButtonTheme } from "./index"
+
+export const buttonReaderRevenue: { button: ButtonTheme } = {
+	button: {
+		textPrimary: palette.text.readerRevenue.ctaPrimary,
+		backgroundPrimary: palette.background.readerRevenue.ctaPrimary,
+		backgroundPrimaryHover:
+			palette.background.readerRevenue.ctaPrimaryHover,
+		textSecondary: palette.text.readerRevenue.ctaSecondary,
+		backgroundSecondary: palette.background.readerRevenue.ctaSecondary,
+		backgroundSecondaryHover:
+			palette.background.readerRevenue.ctaSecondaryHover,
+		borderSecondary: palette.border.readerRevenue.ctaSecondary,
+	},
+}
+
+export const buttonReaderRevenueYellow: { button: ButtonTheme } = {
+	button: {
+		textPrimary: palette.text.readerRevenueYellow.ctaPrimary,
+		backgroundPrimary: palette.background.readerRevenueYellow.ctaPrimary,
+		backgroundPrimaryHover:
+			palette.background.readerRevenueYellow.ctaPrimaryHover,
+		textSecondary: palette.text.readerRevenueYellow.ctaSecondary,
+		backgroundSecondary:
+			palette.background.readerRevenueYellow.ctaSecondary,
+		backgroundSecondaryHover:
+			palette.background.readerRevenueYellow.ctaSecondaryHover,
+		borderSecondary: palette.border.readerRevenueYellow.ctaSecondary,
+	},
+}


### PR DESCRIPTION
## What is the purpose of this change?

The button component has two Reader Revenue themes that are not used anywhere else. It seems excessive to cntinue to support these themes globally in src-foundations. We should instead inline the themes into the button package itself.

## What does this change?

- inlines the Reader Revenue themes into button
- uses the non-Reader Revenue background colours in the Reader Revenue stories. These backgrounds have the same hex values.
