### PR TITLE
Delete reader revenue themes from foundations

### DIFF
--- a/packages/foundations/src/palette.ts
+++ b/packages/foundations/src/palette.ts
@@ -111,18 +111,6 @@ const text = {
 		linkSecondary: neutral[7],
 		linkSecondaryHover: neutral[7],
 	},
-	readerRevenue: {
-		primary: neutral[100],
-		secondary: neutral[60],
-		ctaPrimary: brand.main,
-		ctaSecondary: brandYellow.main,
-	},
-	readerRevenueYellow: {
-		primary: neutral[7],
-		secondary: neutral[60],
-		ctaPrimary: neutral[100],
-		ctaSecondary: neutral[7],
-	},
 }
 const background = {
 	primary: neutral[100],
@@ -154,20 +142,6 @@ const background = {
 		ctaSecondary: brandYellow.dark,
 		ctaSecondaryHover: "#F2AE00",
 	},
-	readerRevenue: {
-		primary: brand.main,
-		ctaPrimary: brandYellow.main,
-		ctaPrimaryHover: brandYellow.dark,
-		ctaSecondary: brand.main,
-		ctaSecondaryHover: "#234B8A",
-	},
-	readerRevenueYellow: {
-		primary: brandYellow.main,
-		ctaPrimary: neutral[7],
-		ctaPrimaryHover: "#454545",
-		ctaSecondary: brandYellow.main,
-		ctaSecondaryHover: brandYellow.dark,
-	},
 }
 const border = {
 	primary: neutral[60],
@@ -184,12 +158,6 @@ const border = {
 		error: error.bright,
 		radio: brand.faded,
 		radioHover: neutral[100],
-	},
-	readerRevenue: {
-		ctaSecondary: brandYellow.main,
-	},
-	readerRevenueYellow: {
-		ctaSecondary: neutral[7],
 	},
 }
 

--- a/packages/foundations/src/themes/button.ts
+++ b/packages/foundations/src/themes/button.ts
@@ -52,39 +52,8 @@ export const buttonBrandYellow: { button: ButtonTheme } = {
 	},
 }
 
-export const buttonReaderRevenue: { button: ButtonTheme } = {
-	button: {
-		textPrimary: palette.text.readerRevenue.ctaPrimary,
-		backgroundPrimary: palette.background.readerRevenue.ctaPrimary,
-		backgroundPrimaryHover:
-			palette.background.readerRevenue.ctaPrimaryHover,
-		textSecondary: palette.text.readerRevenue.ctaSecondary,
-		backgroundSecondary: palette.background.readerRevenue.ctaSecondary,
-		backgroundSecondaryHover:
-			palette.background.readerRevenue.ctaSecondaryHover,
-		borderSecondary: palette.border.readerRevenue.ctaSecondary,
-	},
-}
-
-export const buttonReaderRevenueYellow: { button: ButtonTheme } = {
-	button: {
-		textPrimary: palette.text.readerRevenueYellow.ctaPrimary,
-		backgroundPrimary: palette.background.readerRevenueYellow.ctaPrimary,
-		backgroundPrimaryHover:
-			palette.background.readerRevenueYellow.ctaPrimaryHover,
-		textSecondary: palette.text.readerRevenueYellow.ctaSecondary,
-		backgroundSecondary:
-			palette.background.readerRevenueYellow.ctaSecondary,
-		backgroundSecondaryHover:
-			palette.background.readerRevenueYellow.ctaSecondaryHover,
-		borderSecondary: palette.border.readerRevenueYellow.ctaSecondary,
-	},
-}
-
 export const button = {
 	buttonLight,
 	buttonBrand,
 	buttonBrandYellow,
-	buttonReaderRevenue,
-	buttonReaderRevenueYellow,
 }

--- a/packages/foundations/src/themes/index.ts
+++ b/packages/foundations/src/themes/index.ts
@@ -4,13 +4,7 @@ export * from "./link"
 export * from "./radio"
 export * from "./text-input"
 
-import {
-	buttonLight,
-	buttonBrand,
-	buttonBrandYellow,
-	buttonReaderRevenue,
-	buttonReaderRevenueYellow,
-} from "./button"
+import { buttonLight, buttonBrand, buttonBrandYellow } from "./button"
 import { inlineErrorLight, inlineErrorBrand } from "./inline-error"
 import { linkLight, linkBrand, linkBrandYellow } from "./link"
 import { radioLight, radioBrand } from "./radio"
@@ -34,12 +28,4 @@ export const brand = {
 export const brandYellow = {
 	...buttonBrandYellow,
 	...linkBrandYellow,
-}
-
-export const readerRevenue = {
-	...buttonReaderRevenue,
-}
-
-export const readerRevenueYellow = {
-	...buttonReaderRevenueYellow,
 }


### PR DESCRIPTION
## What is the purpose of this change?

The reader revenue themes are specific to buttons and don't need to exist in foundations.

## What does this change?

- delete reader revenue themes for buttons from foundations
- delete reader revenue functional colours from foundations

These now exist in the button component (#163 and #161)
