### PR TITLE
Remove reader revenue themes from helpers

### DIFF
--- a/packages/button/stories.tsx
+++ b/packages/button/stories.tsx
@@ -96,7 +96,7 @@ priorityBlue.story = {
 	name: "priority blue",
 	parameters: {
 		backgrounds: [
-			Object.assign({}, { default: true }, storybookBackgrounds.blue),
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
 		],
 	},
 }
@@ -114,7 +114,11 @@ priorityYellow.story = {
 	name: "priority yellow",
 	parameters: {
 		backgrounds: [
-			Object.assign({}, { default: true }, storybookBackgrounds.yellow),
+			Object.assign(
+				{},
+				{ default: true },
+				storybookBackgrounds.brandYellow,
+			),
 		],
 	},
 }
@@ -132,7 +136,7 @@ priorityReaderRevenueBlue.story = {
 	name: "priority reader revenue blue",
 	parameters: {
 		backgrounds: [
-			Object.assign({}, { default: true }, storybookBackgrounds.blue),
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
 		],
 	},
 }
@@ -150,7 +154,11 @@ priorityReaderRevenueYellow.story = {
 	name: "priority reader revenue yellow",
 	parameters: {
 		backgrounds: [
-			Object.assign({}, { default: true }, storybookBackgrounds.yellow),
+			Object.assign(
+				{},
+				{ default: true },
+				storybookBackgrounds.brandYellow,
+			),
 		],
 	},
 }

--- a/packages/helpers/storybook-bg.ts
+++ b/packages/helpers/storybook-bg.ts
@@ -1,23 +1,15 @@
 import { palette } from "@guardian/src-foundations"
-import { Appearance } from "./types"
+import { ThemeName } from "./types"
 
 const storybookBackgrounds: {
-	[key in Appearance]: {
-		name: string
+	[key in ThemeName]: {
+		name: ThemeName
 		value: string
 	}
 } = {
 	light: { name: "light", value: palette.neutral[100] },
-	blue: { name: "blue", value: palette.brand.main },
-	yellow: { name: "yellow", value: palette.brandYellow.main },
-	"reader revenue blue": {
-		name: "reader revenue blue",
-		value: palette.brand.main,
-	},
-	"reader revenue yellow": {
-		name: "reader revenue yellow",
-		value: palette.brandYellow.main,
-	},
+	brand: { name: "brand", value: palette.brand.main },
+	brandYellow: { name: "brandYellow", value: palette.brandYellow.main },
 }
 
 Object.freeze(storybookBackgrounds)

--- a/packages/helpers/types.ts
+++ b/packages/helpers/types.ts
@@ -1,6 +1,1 @@
-export type Appearance =
-	| "light"
-	| "blue"
-	| "yellow"
-	| "reader revenue blue"
-	| "reader revenue yellow"
+export type ThemeName = "light" | "brand" | "brandYellow"

--- a/packages/inline-error/stories.tsx
+++ b/packages/inline-error/stories.tsx
@@ -5,50 +5,45 @@ import {
 	inlineErrorLight,
 	inlineErrorBrand,
 } from "@guardian/src-foundations/themes"
-import { Appearance, storybookBackgrounds } from "@guardian/src-helpers"
+import { ThemeName, storybookBackgrounds } from "@guardian/src-helpers"
 import { InlineError } from "./index"
 
 export default {
 	title: "InlineError",
 }
 
-const appearances: {
-	name: Appearance
+const themes: {
+	name: ThemeName
 	theme: { inlineError: InlineErrorTheme }
 }[] = [
 	{
 		name: "light",
 		theme: inlineErrorLight,
 	},
-	{ name: "blue", theme: inlineErrorBrand },
+	{ name: "brand", theme: inlineErrorBrand },
 ]
 
-const [defaultLight, defaultBlue] = appearances.map(
-	(appearance: {
-		name: Appearance
-		theme: { inlineError: InlineErrorTheme }
-	}) => {
-		const story = () => (
-			<ThemeProvider theme={appearance.theme}>
-				<InlineError>Please enter your name</InlineError>
-			</ThemeProvider>
-		)
+const [defaultLight, defaultBlue] = themes.map(({ name, theme }) => {
+	const story = () => (
+		<ThemeProvider theme={theme}>
+			<InlineError>Please enter your name</InlineError>
+		</ThemeProvider>
+	)
 
-		story.story = {
-			name: `default ${appearance.name}`,
-			parameters: {
-				backgrounds: [
-					Object.assign(
-						{},
-						{ default: true },
-						storybookBackgrounds[appearance.name],
-					),
-				],
-			},
-		}
+	story.story = {
+		name: `default ${name}`,
+		parameters: {
+			backgrounds: [
+				Object.assign(
+					{},
+					{ default: true },
+					storybookBackgrounds[name],
+				),
+			],
+		},
+	}
 
-		return story
-	},
-)
+	return story
+})
 
 export { defaultLight, defaultBlue }

--- a/packages/link/stories.tsx
+++ b/packages/link/stories.tsx
@@ -66,7 +66,7 @@ priorityBlue.story = {
 	name: "priority blue",
 	parameters: {
 		backgrounds: [
-			Object.assign({}, { default: true }, storybookBackgrounds.blue),
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
 		],
 	},
 }
@@ -84,7 +84,11 @@ priorityYellow.story = {
 	name: "priority yellow",
 	parameters: {
 		backgrounds: [
-			Object.assign({}, { default: true }, storybookBackgrounds.yellow),
+			Object.assign(
+				{},
+				{ default: true },
+				storybookBackgrounds.brandYellow,
+			),
 		],
 	},
 }

--- a/packages/radio/stories.tsx
+++ b/packages/radio/stories.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { css } from "@emotion/core"
 import { storybookBackgrounds } from "@guardian/src-helpers"
 import { RadioGroup, Radio, radioLight, radioBrand } from "./index"
-import { Appearance } from "@guardian/src-helpers"
+import { ThemeName } from "@guardian/src-helpers"
 import { ThemeProvider } from "emotion-theming"
 
 /* eslint-disable react/jsx-key */
@@ -45,53 +45,51 @@ export default {
 	title: "Radio",
 }
 
-const appearances: {
-	name: Appearance
+const themes: {
+	name: ThemeName
 	theme: {}
 }[] = [
 	{
 		name: "light",
 		theme: radioLight,
 	},
-	{ name: "blue", theme: radioBrand },
+	{ name: "brand", theme: radioBrand },
 ]
 
-const [verticalLight, verticalBlue] = appearances.map(
-	(appearance: { name: Appearance; theme: {} }) => {
-		const story = () => (
-			<ThemeProvider theme={appearance.theme}>
-				<RadioGroup name="colours">
-					{radios.map((radio, index) =>
-						React.cloneElement(radio, { key: index }),
-					)}
-				</RadioGroup>
-			</ThemeProvider>
-		)
-		story.story = {
-			name: `vertical ${appearance.name}`,
-			parameters: {
-				backgrounds: [
-					Object.assign(
-						{},
-						{ default: true },
-						storybookBackgrounds[appearance.name],
-					),
-				],
-			},
-		}
+const [verticalLight, verticalBlue] = themes.map(({ name, theme }) => {
+	const story = () => (
+		<ThemeProvider theme={theme}>
+			<RadioGroup name="colours">
+				{radios.map((radio, index) =>
+					React.cloneElement(radio, { key: index }),
+				)}
+			</RadioGroup>
+		</ThemeProvider>
+	)
+	story.story = {
+		name: `vertical ${name}`,
+		parameters: {
+			backgrounds: [
+				Object.assign(
+					{},
+					{ default: true },
+					storybookBackgrounds[name],
+				),
+			],
+		},
+	}
 
-		return story
-	},
-)
+	return story
+})
 
 const narrow = css`
 	width: 30rem;
 `
 
-const [supportingTextLight, supportingTextBlue] = appearances.map(
-	(appearance: { name: Appearance; theme: {} }) => {
+const [supportingTextLight, supportingTextBlue] = themes.map(
+	({ name, theme }) => {
 		const story = () => (
-			<ThemeProvider theme={appearance.theme}>
+			<ThemeProvider theme={theme}>
 				<div css={narrow}>
 					<RadioGroup name="payment-options">
 						{radiosWithSupportingText.map((radio, index) =>
@@ -102,13 +100,13 @@ const [supportingTextLight, supportingTextBlue] = appearances.map(
 			</ThemeProvider>
 		)
 		story.story = {
-			name: `supporting text ${appearance.name}`,
+			name: `supporting text ${name}`,
 			parameters: {
 				backgrounds: [
 					Object.assign(
 						{},
 						{ default: true },
-						storybookBackgrounds[appearance.name],
+						storybookBackgrounds[name],
 					),
 				],
 			},
@@ -128,34 +126,32 @@ horizontal.story = {
 	name: "orientation horizontal",
 }
 
-const [errorLight, errorBlue] = appearances.map(
-	(appearance: { name: Appearance; theme: {} }) => {
-		const story = () => (
-			<ThemeProvider theme={appearance.theme}>
-				<RadioGroup name="colours" error="Please select a colour">
-					{unselectedRadios.map((radio, index) =>
-						React.cloneElement(radio, { key: index }),
-					)}
-				</RadioGroup>
-			</ThemeProvider>
-		)
+const [errorLight, errorBlue] = themes.map(({ name, theme }) => {
+	const story = () => (
+		<ThemeProvider theme={theme}>
+			<RadioGroup name="colours" error="Please select a colour">
+				{unselectedRadios.map((radio, index) =>
+					React.cloneElement(radio, { key: index }),
+				)}
+			</RadioGroup>
+		</ThemeProvider>
+	)
 
-		story.story = {
-			name: `error ${appearance.name}`,
-			parameters: {
-				backgrounds: [
-					Object.assign(
-						{},
-						{ default: true },
-						storybookBackgrounds[appearance.name],
-					),
-				],
-			},
-		}
+	story.story = {
+		name: `error ${name}`,
+		parameters: {
+			backgrounds: [
+				Object.assign(
+					{},
+					{ default: true },
+					storybookBackgrounds[name],
+				),
+			],
+		},
+	}
 
-		return story
-	},
-)
+	return story
+})
 
 export {
 	verticalLight,

--- a/packages/text-input/stories.tsx
+++ b/packages/text-input/stories.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { css } from "@emotion/core"
 import { ThemeProvider } from "emotion-theming"
-import { storybookBackgrounds, Appearance } from "@guardian/src-helpers"
+import { storybookBackgrounds, ThemeName } from "@guardian/src-helpers"
 import { space } from "@guardian/src-foundations"
 import { TextInput, textInputLight } from "./index"
 
@@ -9,8 +9,8 @@ export default {
 	title: "TextInput",
 }
 
-const appearances: {
-	name: Appearance
+const themes: {
+	name: ThemeName
 	theme: {}
 }[] = [
 	{
@@ -23,151 +23,141 @@ const constrainedWith = css`
 	width: 30em;
 `
 
-const [defaultLight] = appearances.map(
-	({ name, theme }: { name: Appearance; theme: {} }) => {
-		const story = () => (
-			<ThemeProvider theme={theme}>
-				<div css={constrainedWith}>
-					<TextInput label="First name" />
-				</div>
-			</ThemeProvider>
-		)
+const [defaultLight] = themes.map(({ name, theme }) => {
+	const story = () => (
+		<ThemeProvider theme={theme}>
+			<div css={constrainedWith}>
+				<TextInput label="First name" />
+			</div>
+		</ThemeProvider>
+	)
 
-		story.story = {
-			name: `default ${name}`,
-			parameters: {
-				backgrounds: [
-					Object.assign(
-						{},
-						{ default: true },
-						storybookBackgrounds[name],
-					),
-				],
-			},
-		}
+	story.story = {
+		name: `default ${name}`,
+		parameters: {
+			backgrounds: [
+				Object.assign(
+					{},
+					{ default: true },
+					storybookBackgrounds[name],
+				),
+			],
+		},
+	}
 
-		return story
-	},
-)
+	return story
+})
 
-const [optionalLight] = appearances.map(
-	({ name, theme }: { name: Appearance; theme: {} }) => {
-		const story = () => (
-			<ThemeProvider theme={theme}>
-				<div css={constrainedWith}>
-					<TextInput label="First name" optional={true} />
-				</div>
-			</ThemeProvider>
-		)
+const [optionalLight] = themes.map(({ name, theme }) => {
+	const story = () => (
+		<ThemeProvider theme={theme}>
+			<div css={constrainedWith}>
+				<TextInput label="First name" optional={true} />
+			</div>
+		</ThemeProvider>
+	)
 
-		story.story = {
-			name: `optional ${name}`,
-			parameters: {
-				backgrounds: [
-					Object.assign(
-						{},
-						{ default: true },
-						storybookBackgrounds[name],
-					),
-				],
-			},
-		}
+	story.story = {
+		name: `optional ${name}`,
+		parameters: {
+			backgrounds: [
+				Object.assign(
+					{},
+					{ default: true },
+					storybookBackgrounds[name],
+				),
+			],
+		},
+	}
 
-		return story
-	},
-)
-const [supportingTextLight] = appearances.map(
-	({ name, theme }: { name: Appearance; theme: {} }) => {
-		const story = () => (
-			<ThemeProvider theme={theme}>
-				<div css={constrainedWith}>
-					<TextInput label="Email" supporting="alex@example.com" />
-				</div>
-			</ThemeProvider>
-		)
+	return story
+})
+const [supportingTextLight] = themes.map(({ name, theme }) => {
+	const story = () => (
+		<ThemeProvider theme={theme}>
+			<div css={constrainedWith}>
+				<TextInput label="Email" supporting="alex@example.com" />
+			</div>
+		</ThemeProvider>
+	)
 
-		story.story = {
-			name: `supporting text ${name}`,
-			parameters: {
-				backgrounds: [
-					Object.assign(
-						{},
-						{ default: true },
-						storybookBackgrounds[name],
-					),
-				],
-			},
-		}
+	story.story = {
+		name: `supporting text ${name}`,
+		parameters: {
+			backgrounds: [
+				Object.assign(
+					{},
+					{ default: true },
+					storybookBackgrounds[name],
+				),
+			],
+		},
+	}
 
-		return story
-	},
-)
+	return story
+})
 
 const spacer = css`
 	margin-bottom: ${space[3]}px;
 `
-const [widthsLight] = appearances.map(
-	({ name, theme }: { name: Appearance; theme: {} }) => {
-		const story = () => (
-			<ThemeProvider theme={theme}>
-				<div css={spacer}>
-					<TextInput label="First name" width={30} />
-				</div>
-				<div css={spacer}>
-					<TextInput label="Postcode" width={10} />
-				</div>
-				<div css={spacer}>
-					<TextInput label="Year of birth" width={4} />
-				</div>
-			</ThemeProvider>
-		)
+const [widthsLight] = themes.map(({ name, theme }) => {
+	const story = () => (
+		<ThemeProvider theme={theme}>
+			<div css={spacer}>
+				<TextInput label="First name" width={30} />
+			</div>
+			<div css={spacer}>
+				<TextInput label="Postcode" width={10} />
+			</div>
+			<div css={spacer}>
+				<TextInput label="Year of birth" width={4} />
+			</div>
+		</ThemeProvider>
+	)
 
-		story.story = {
-			name: `widths ${name}`,
-			parameters: {
-				backgrounds: [
-					Object.assign(
-						{},
-						{ default: true },
-						storybookBackgrounds[name],
-					),
-				],
-			},
-		}
+	story.story = {
+		name: `widths ${name}`,
+		parameters: {
+			backgrounds: [
+				Object.assign(
+					{},
+					{ default: true },
+					storybookBackgrounds[name],
+				),
+			],
+		},
+	}
 
-		return story
-	},
-)
+	return story
+})
 
-const [errorWithMessageLight] = appearances.map(
-	({ name, theme }: { name: Appearance; theme: {} }) => {
-		const story = () => (
-			<ThemeProvider theme={theme}>
-				<div css={constrainedWith}>
-					<TextInput
-						label="First name"
-						error="Enter your first name below"
-					/>
-				</div>
-			</ThemeProvider>
-		)
+const [errorWithMessageLight] = themes.map(({ name, theme }) => {
+	const story = () => (
+		<ThemeProvider theme={theme}>
+			<div css={constrainedWith}>
+				<TextInput
+					label="First name"
+					error="Enter your first name below"
+				/>
+			</div>
+		</ThemeProvider>
+	)
 
-		story.story = {
-			name: `error with message ${name}`,
-			parameters: {
-				backgrounds: [
-					Object.assign(
-						{},
-						{ default: true },
-						storybookBackgrounds[name],
-					),
-				],
-			},
-		}
+	story.story = {
+		name: `error with message ${name}`,
+		parameters: {
+			backgrounds: [
+				Object.assign(
+					{},
+					{ default: true },
+					storybookBackgrounds[name],
+				),
+			],
+		},
+	}
 
-		return story
-	},
-)
+	return story
+})
 
 export {
 	defaultLight,


### PR DESCRIPTION
## What is the purpose of this change?

The custom `readerRevenue` and `readerRevenueYellow` themes don't belong in our global helpers as they are specific to buttons. They also expose background colours that are equivalent to `brand` and `brandYellow` themes, so are superfluous

## What does this change?

- remove reader revenue themes from helpers
- update `Appearance` type to `ThemeName` 
- update storybook backgrounds list to use theme names instead of colour names
- fix resulting type errors across packages (sorry for breaking the one-pckage-per-pull-request rule)
