### PR TITLE
Add mono theme to helpers

### DIFF
--- a/packages/helpers/storybook-bg.ts
+++ b/packages/helpers/storybook-bg.ts
@@ -7,9 +7,13 @@ const storybookBackgrounds: {
 		value: string
 	}
 } = {
-	light: { name: "light", value: palette.neutral[100] },
-	brand: { name: "brand", value: palette.brand.main },
-	brandYellow: { name: "brandYellow", value: palette.brandYellow.main },
+	light: { name: "light", value: palette.background.primary },
+	brand: { name: "brand", value: palette.background.brand.primary },
+	brandYellow: {
+		name: "brandYellow",
+		value: palette.background.brandYellow.primary,
+	},
+	mono: { name: "mono", value: palette.background.mono.primary },
 }
 
 Object.freeze(storybookBackgrounds)

--- a/packages/helpers/types.ts
+++ b/packages/helpers/types.ts
@@ -1,1 +1,1 @@
-export type ThemeName = "light" | "brand" | "brandYellow"
+export type ThemeName = "light" | "brand" | "brandYellow" | "mono"


### PR DESCRIPTION
## What is the purpose of this change?

The mono theme is partially specified in the foundations palette. We should formally add the theme to helpers, to make it available in Storybook.

## What does this change?

- Add the mono theme to helpers
- Update the storybook background helper to use functional colours
