### PR TITLE
Expose mono theme for links

### DIFF
--- a/packages/foundations/src/themes/index.ts
+++ b/packages/foundations/src/themes/index.ts
@@ -6,7 +6,7 @@ export * from "./text-input"
 
 import { buttonLight, buttonBrand, buttonBrandYellow } from "./button"
 import { inlineErrorLight, inlineErrorBrand } from "./inline-error"
-import { linkLight, linkBrand, linkBrandYellow } from "./link"
+import { linkLight, linkBrand, linkBrandYellow, linkMono } from "./link"
 import { radioLight, radioBrand } from "./radio"
 import { textInputLight } from "./text-input"
 
@@ -28,4 +28,8 @@ export const brand = {
 export const brandYellow = {
 	...buttonBrandYellow,
 	...linkBrandYellow,
+}
+
+export const mono = {
+	...linkMono,
 }

--- a/packages/foundations/src/themes/link.ts
+++ b/packages/foundations/src/themes/link.ts
@@ -33,6 +33,16 @@ export const linkBrandYellow: { link: LinkTheme } = {
 		textSecondaryHover: palette.text.brandYellow.linkSecondaryHover,
 	},
 }
+
+export const linkMono: { link: LinkTheme } = {
+	link: {
+		textPrimary: palette.text.mono.linkPrimary,
+		textPrimaryHover: palette.text.mono.linkPrimaryHover,
+		textSecondary: palette.text.mono.linkSecondary,
+		textSecondaryHover: palette.text.mono.linkSecondaryHover,
+	},
+}
+
 export const link = {
 	linkLight,
 	linkBrand,


### PR DESCRIPTION
## What is the purpose of this change?

The mono theme for links is (partially) defined in Figma, but is not yet exposed in the code

## What does this change?

Adds the mono theme for links. This is definitely incomplete (no hover state, primary and secondary colours are the same), but it's a start

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

![Screenshot 2020-01-10 at 11 45 52](https://user-images.githubusercontent.com/5931528/72150945-c6b7b900-339e-11ea-931b-6b27f2cc1793.png)


### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
