### PR TITLE
Document mono theme in link package

### DIFF
--- a/packages/link/README.md
+++ b/packages/link/README.md
@@ -52,3 +52,12 @@ An icon that appears in the link, alongside text
 **`"left" | "right"`** _= "left"_
 
 The side of the link on which the icon appears
+
+## Supported themes
+
+### Standard
+
+-   `light`
+-   `brand`
+-   `brandYellow`
+-   `mono`

--- a/packages/link/index.tsx
+++ b/packages/link/index.tsx
@@ -14,6 +14,7 @@ export {
 	linkLight,
 	linkBrand,
 	linkBrandYellow,
+	linkMono,
 } from "@guardian/src-foundations/themes"
 
 export type Priority = "primary" | "secondary"

--- a/packages/link/stories.tsx
+++ b/packages/link/stories.tsx
@@ -7,7 +7,7 @@ import {
 	SvgChevronLeftSingle,
 } from "@guardian/src-svgs"
 import { size } from "@guardian/src-foundations"
-import { Link, linkLight, linkBrandYellow, linkBrand } from "./index"
+import { Link, linkLight, linkBrandYellow, linkBrand, linkMono } from "./index"
 import { ThemeProvider } from "emotion-theming"
 
 /* eslint-disable react/jsx-key */
@@ -89,6 +89,24 @@ priorityYellow.story = {
 				{ default: true },
 				storybookBackgrounds.brandYellow,
 			),
+		],
+	},
+}
+
+export const priorityMono = () => (
+	<ThemeProvider theme={linkMono}>
+		<div css={flexStart}>
+			{priorityLinks.map((button, index) => (
+				<div key={index}>{button}</div>
+			))}
+		</div>
+	</ThemeProvider>
+)
+priorityMono.story = {
+	name: "priority mono",
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.mono),
 		],
 	},
 }


### PR DESCRIPTION
## What is the purpose of this change?

#167 defined the mono theme for links. We also need to document this.

## What does this change?

- adds story for the mono theme
- adds supported themes to readme
- exposes mono theme from component module
