### PR TITLE
Expose checkbox themes

### DIFF
--- a/packages/foundations/src/palette.ts
+++ b/packages/foundations/src/palette.ts
@@ -80,6 +80,9 @@ const text = {
 	linkPrimaryHover: brand.bright,
 	linkSecondary: neutral[7],
 	linkSecondaryHover: neutral[7],
+	checkbox: neutral[7],
+	checkboxSupporting: neutral[46],
+	checkboxIndeterminate: neutral[46],
 	mono: {
 		primary: neutral[100],
 		secondary: neutral[60],
@@ -100,6 +103,9 @@ const text = {
 		linkPrimaryHover: neutral[100],
 		linkSecondary: neutral[100],
 		linkSecondaryHover: neutral[100],
+		checkbox: neutral[100],
+		checkboxSupporting: brand.faded,
+		checkboxIndeterminate: brand.faded,
 	},
 	brandYellow: {
 		primary: neutral[7],
@@ -134,6 +140,7 @@ const background = {
 		ctaSecondary: brand.pastel,
 		ctaSecondaryHover: "#234B8A",
 		radioChecked: neutral[100],
+		checkboxChecked: neutral[100],
 	},
 	brandYellow: {
 		primary: brandYellow.main,
@@ -154,10 +161,15 @@ const border = {
 	checkbox: neutral[60],
 	checkboxHover: brand.bright,
 	checkboxChecked: brand.bright,
+	checkboxError: error.main,
 	brand: {
 		error: error.bright,
 		radio: brand.faded,
 		radioHover: neutral[100],
+		checkbox: brand.faded,
+		checkboxHover: neutral[100],
+		checkboxChecked: neutral[100],
+		checkboxError: error.bright,
 	},
 }
 

--- a/packages/foundations/src/themes/checkbox.ts
+++ b/packages/foundations/src/themes/checkbox.ts
@@ -1,0 +1,51 @@
+import { palette } from "../index"
+import {
+	inlineErrorLight,
+	inlineErrorBrand,
+	InlineErrorTheme,
+} from "./inline-error"
+
+export type CheckboxTheme = {
+	border: string
+	borderHover: string
+	borderChecked: string
+	borderError: string
+	backgroundChecked: string
+	text: string
+	textSupporting: string
+	textIndeterminate: string
+}
+
+export const checkboxLight: {
+	checkbox: CheckboxTheme
+	inlineError: InlineErrorTheme
+} = {
+	checkbox: {
+		border: palette.border.checkbox,
+		borderHover: palette.border.checkboxHover,
+		borderChecked: palette.border.checkboxChecked,
+		borderError: palette.border.checkboxError,
+		backgroundChecked: palette.background.checkboxChecked,
+		text: palette.text.checkbox,
+		textSupporting: palette.text.checkboxSupporting,
+		textIndeterminate: palette.text.checkboxIndeterminate,
+	},
+	...inlineErrorLight,
+}
+
+export const checkboxBrand: {
+	checkbox: CheckboxTheme
+	inlineError: InlineErrorTheme
+} = {
+	checkbox: {
+		border: palette.border.brand.checkbox,
+		borderHover: palette.border.brand.checkboxHover,
+		borderChecked: palette.border.brand.checkboxChecked,
+		borderError: palette.border.brand.checkboxError,
+		backgroundChecked: palette.background.brand.checkboxChecked,
+		text: palette.text.brand.checkbox,
+		textSupporting: palette.text.brand.checkboxSupporting,
+		textIndeterminate: palette.text.brand.checkboxIndeterminate,
+	},
+	...inlineErrorBrand,
+}

--- a/packages/foundations/src/themes/index.ts
+++ b/packages/foundations/src/themes/index.ts
@@ -1,10 +1,12 @@
 export * from "./button"
+export * from "./checkbox"
 export * from "./inline-error"
 export * from "./link"
 export * from "./radio"
 export * from "./text-input"
 
 import { buttonLight, buttonBrand, buttonBrandYellow } from "./button"
+import { checkboxLight, checkboxBrand } from "./checkbox"
 import { inlineErrorLight, inlineErrorBrand } from "./inline-error"
 import { linkLight, linkBrand, linkBrandYellow, linkMono } from "./link"
 import { radioLight, radioBrand } from "./radio"
@@ -12,6 +14,7 @@ import { textInputLight } from "./text-input"
 
 export const light = {
 	...buttonLight,
+	...checkboxLight,
 	...inlineErrorLight,
 	...linkLight,
 	...radioLight,
@@ -20,6 +23,7 @@ export const light = {
 
 export const brand = {
 	...buttonBrand,
+	...checkboxBrand,
 	...inlineErrorBrand,
 	...linkBrand,
 	...radioBrand,


### PR DESCRIPTION
## What is the purpose of this change?

Checkbox can support brand and light themes. These should be exposed from foundations.

## What does this change?

Expose checkbox themes from foundations.
<!--
Give an overview of the changes you have made
-->
