### PR TITLE
Hook up checkbox themes

### DIFF
--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -77,3 +77,10 @@ Whether checkbox is checked
 **`boolean`**
 
 Whether checkbox is in an indeterminate ("mixed") state
+
+## Supported themes
+
+### Standard
+
+-   `light`
+-   `brand`

--- a/packages/checkbox/index.tsx
+++ b/packages/checkbox/index.tsx
@@ -12,6 +12,7 @@ import {
 	errorCheckbox,
 } from "./styles"
 import { InlineError } from "@guardian/src-inline-error"
+export { checkboxLight, checkboxBrand } from "@guardian/src-foundations/themes"
 
 const CheckboxGroup = ({
 	name,
@@ -47,8 +48,8 @@ const LabelText = ({
 }) => {
 	return (
 		<div
-			css={[
-				labelText,
+			css={theme => [
+				labelText(theme.checkbox && theme),
 				hasSupportingText ? labelTextWithSupportingText : "",
 			]}
 		>
@@ -58,7 +59,11 @@ const LabelText = ({
 }
 
 const SupportingText = ({ children }: { children: ReactNode }) => {
-	return <div css={supportingText}>{children}</div>
+	return (
+		<div css={theme => supportingText(theme.checkbox && theme)}>
+			{children}
+		</div>
+	)
 }
 
 const Checkbox = ({
@@ -101,16 +106,29 @@ const Checkbox = ({
 		}
 	}
 	return (
-		<label css={[label, supporting ? labelWithSupportingText : ""]}>
+		<label
+			css={theme => [
+				label(theme.checkbox && theme),
+				supporting ? labelWithSupportingText : "",
+			]}
+		>
 			<input
-				css={[checkbox, error ? errorCheckbox : ""]}
+				css={theme => [
+					checkbox(theme.checkbox && theme),
+					error ? errorCheckbox(theme.checkbox && theme) : "",
+				]}
 				value={value}
 				aria-invalid={error}
 				aria-checked={isChecked()}
 				ref={setCheckboxState}
 				{...props}
 			/>
-			<span css={[tick, supporting ? tickWithSupportingText : ""]} />
+			<span
+				css={theme => [
+					tick(theme.checkbox && theme),
+					supporting ? tickWithSupportingText : "",
+				]}
+			/>
 			{supporting ? (
 				<div>
 					<LabelText hasSupportingText={true}>

--- a/packages/checkbox/stories/default.tsx
+++ b/packages/checkbox/stories/default.tsx
@@ -1,6 +1,8 @@
 import React from "react"
+import { ThemeProvider } from "emotion-theming"
+import { storybookBackgrounds } from "@guardian/src-helpers"
 
-import { CheckboxGroup, Checkbox } from "../index"
+import { CheckboxGroup, Checkbox, checkboxLight, checkboxBrand } from "../index"
 
 /* eslint-disable react/jsx-key */
 const checkboxes = [
@@ -10,15 +12,36 @@ const checkboxes = [
 /* eslint-enable react/jsx-key */
 
 const defaultLight = () => (
-	<CheckboxGroup name="emails">
-		{checkboxes.map((checkbox, index) =>
-			React.cloneElement(checkbox, { key: index }),
-		)}
-	</CheckboxGroup>
+	<ThemeProvider theme={checkboxLight}>
+		<CheckboxGroup name="emails">
+			{checkboxes.map((checkbox, index) =>
+				React.cloneElement(checkbox, { key: index }),
+			)}
+		</CheckboxGroup>
+	</ThemeProvider>
 )
 
 defaultLight.story = {
 	name: "default light",
 }
 
-export { defaultLight }
+const defaultBlue = () => (
+	<ThemeProvider theme={checkboxBrand}>
+		<CheckboxGroup name="emails">
+			{checkboxes.map((checkbox, index) =>
+				React.cloneElement(checkbox, { key: index }),
+			)}
+		</CheckboxGroup>
+	</ThemeProvider>
+)
+
+defaultBlue.story = {
+	name: "default blue",
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
+		],
+	},
+}
+
+export { defaultLight, defaultBlue }

--- a/packages/checkbox/stories/error.tsx
+++ b/packages/checkbox/stories/error.tsx
@@ -1,21 +1,48 @@
 import React from "react"
+import { ThemeProvider } from "emotion-theming"
+import { storybookBackgrounds } from "@guardian/src-helpers"
 
-import { CheckboxGroup, Checkbox } from "../index"
+import { CheckboxGroup, Checkbox, checkboxLight, checkboxBrand } from "../index"
 
 const errorLight = () => (
-	<CheckboxGroup
-		name="tandcs"
-		error="Tick the box to accept the terms and conditions"
-	>
-		<Checkbox
-			value="tandcs-accept"
-			label="I understand the terms and conditions"
-		/>
-	</CheckboxGroup>
+	<ThemeProvider theme={checkboxLight}>
+		<CheckboxGroup
+			name="tandcs"
+			error="Tick the box to accept the terms and conditions"
+		>
+			<Checkbox
+				value="tandcs-accept"
+				label="I understand the terms and conditions"
+			/>
+		</CheckboxGroup>
+	</ThemeProvider>
 )
 
 errorLight.story = {
 	name: "error light",
 }
 
-export { errorLight }
+const errorBlue = () => (
+	<ThemeProvider theme={checkboxBrand}>
+		<CheckboxGroup
+			name="tandcs"
+			error="Tick the box to accept the terms and conditions"
+		>
+			<Checkbox
+				value="tandcs-accept"
+				label="I understand the terms and conditions"
+			/>
+		</CheckboxGroup>
+	</ThemeProvider>
+)
+
+errorBlue.story = {
+	name: "error blue",
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
+		],
+	},
+}
+
+export { errorLight, errorBlue }

--- a/packages/checkbox/stories/indeterminate.tsx
+++ b/packages/checkbox/stories/indeterminate.tsx
@@ -1,17 +1,40 @@
 import React from "react"
+import { ThemeProvider } from "emotion-theming"
+import { storybookBackgrounds } from "@guardian/src-helpers"
 
-import { Checkbox } from "../index"
+import { Checkbox, checkboxLight, checkboxBrand } from "../index"
 
 const indeterminateLight = () => (
-	<Checkbox
-		indeterminate={true}
-		value="indeterminate"
-		label="Indeterminate"
-	/>
+	<ThemeProvider theme={checkboxLight}>
+		<Checkbox
+			indeterminate={true}
+			value="indeterminate"
+			label="Indeterminate"
+		/>
+	</ThemeProvider>
 )
 
 indeterminateLight.story = {
 	name: "indeterminate light",
 }
 
-export { indeterminateLight }
+const indeterminateBlue = () => (
+	<ThemeProvider theme={checkboxBrand}>
+		<Checkbox
+			indeterminate={true}
+			value="indeterminate"
+			label="Indeterminate"
+		/>
+	</ThemeProvider>
+)
+
+indeterminateBlue.story = {
+	name: "indeterminate blue",
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
+		],
+	},
+}
+
+export { indeterminateLight, indeterminateBlue }

--- a/packages/checkbox/stories/supporting-text.tsx
+++ b/packages/checkbox/stories/supporting-text.tsx
@@ -1,7 +1,9 @@
 import React from "react"
 import { css } from "@emotion/core"
+import { ThemeProvider } from "emotion-theming"
+import { storybookBackgrounds } from "@guardian/src-helpers"
 
-import { CheckboxGroup, Checkbox } from "../index"
+import { CheckboxGroup, Checkbox, checkboxLight, checkboxBrand } from "../index"
 
 /* eslint-disable react/jsx-key */
 const checkboxesWithSupportingText = [
@@ -36,11 +38,13 @@ const narrow = css`
 
 const supportingTextLight = () => (
 	<div css={narrow}>
-		<CheckboxGroup name="emails">
-			{checkboxesWithSupportingText.map((checkbox, index) =>
-				React.cloneElement(checkbox, { key: index }),
-			)}
-		</CheckboxGroup>
+		<ThemeProvider theme={checkboxLight}>
+			<CheckboxGroup name="emails">
+				{checkboxesWithSupportingText.map((checkbox, index) =>
+					React.cloneElement(checkbox, { key: index }),
+				)}
+			</CheckboxGroup>
+		</ThemeProvider>
 	</div>
 )
 
@@ -48,4 +52,25 @@ supportingTextLight.story = {
 	name: "supporting text light",
 }
 
-export { supportingTextLight }
+const supportingTextBlue = () => (
+	<div css={narrow}>
+		<ThemeProvider theme={checkboxBrand}>
+			<CheckboxGroup name="emails">
+				{checkboxesWithSupportingText.map((checkbox, index) =>
+					React.cloneElement(checkbox, { key: index }),
+				)}
+			</CheckboxGroup>
+		</ThemeProvider>
+	</div>
+)
+
+supportingTextBlue.story = {
+	name: "supporting text blue",
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
+		],
+	},
+}
+
+export { supportingTextLight, supportingTextBlue }

--- a/packages/checkbox/styles.ts
+++ b/packages/checkbox/styles.ts
@@ -1,7 +1,8 @@
 import { css } from "@emotion/core"
-import { palette, space, size, transitions } from "@guardian/src-foundations"
+import { space, size, transitions } from "@guardian/src-foundations"
 import { textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
+import { checkboxLight, CheckboxTheme } from "@guardian/src-foundations/themes"
 
 export const fieldset = css`
 	display: flex;
@@ -12,7 +13,9 @@ export const fieldset = css`
 	margin: 0;
 `
 
-export const label = css`
+export const label = ({
+	checkbox,
+}: { checkbox: CheckboxTheme } = checkboxLight) => css`
 	position: relative;
 	display: flex;
 	align-items: center;
@@ -21,7 +24,7 @@ export const label = css`
 
 	&:hover {
 		input {
-			border-color: ${palette.border.checkboxHover};
+			border-color: ${checkbox.borderHover};
 		}
 	}
 `
@@ -31,7 +34,9 @@ export const labelWithSupportingText = css`
 	margin-bottom: ${space[3]}px;
 `
 
-export const checkbox = css`
+export const checkbox = ({
+	checkbox,
+}: { checkbox: CheckboxTheme } = checkboxLight) => css`
 	flex: 0 0 auto;
 	box-sizing: border-box;
 	display: inline-block;
@@ -45,7 +50,7 @@ export const checkbox = css`
 	transition: box-shadow ${transitions.short};
 	transition-delay: 0.08s;
 
-	color: ${palette.border.checkbox};
+	color: ${checkbox.border};
 
 	&:focus {
 		${focusHalo};
@@ -54,7 +59,7 @@ export const checkbox = css`
 	@supports (appearance: none) {
 		appearance: none;
 		&:checked {
-			border: 2px solid ${palette.border.checkboxChecked};
+			border: 2px solid ${checkbox.borderChecked};
 
 			& ~ span:before {
 				right: 0;
@@ -67,7 +72,7 @@ export const checkbox = css`
 		&:indeterminate {
 			&:after {
 				${textSans.xlarge()};
-				color: ${palette.text.secondary};
+				color: ${checkbox.textIndeterminate};
 				content: "-";
 				position: absolute;
 				top: -10px;
@@ -78,21 +83,27 @@ export const checkbox = css`
 	}
 `
 
-export const labelText = css`
+export const labelText = ({
+	checkbox,
+}: { checkbox: CheckboxTheme } = checkboxLight) => css`
 	${textSans.medium()};
-	color: ${palette.text.primary};
+	color: ${checkbox.text};
 `
 
 export const labelTextWithSupportingText = css`
 	${textSans.medium()};
 `
 
-export const supportingText = css`
+export const supportingText = ({
+	checkbox,
+}: { checkbox: CheckboxTheme } = checkboxLight) => css`
 	${textSans.small({ lineHeight: "regular" })};
-	color: ${palette.text.secondary};
+	color: ${checkbox.textSupporting};
 `
 
-export const tick = css`
+export const tick = ({
+	checkbox,
+}: { checkbox: CheckboxTheme } = checkboxLight) => css`
 	@supports (appearance: none) {
 		/* overall positional properties */
 		position: absolute;
@@ -108,7 +119,7 @@ export const tick = css`
 		&:before {
 			position: absolute;
 			display: block;
-			background-color: ${palette.background.checkboxChecked};
+			background-color: ${checkbox.backgroundChecked};
 			transition: all ${transitions.short} ease-in-out;
 			content: "";
 		}
@@ -139,6 +150,8 @@ export const tickWithSupportingText = css`
 	}
 `
 
-export const errorCheckbox = css`
-	border: 4px solid ${palette.border.error};
+export const errorCheckbox = ({
+	checkbox,
+}: { checkbox: CheckboxTheme } = checkboxLight) => css`
+	border: 4px solid ${checkbox.borderError};
 `


### PR DESCRIPTION
## What is the purpose of this change?

Checkbox themes are exposed by foundations. We need to hook them up. This will add support for the `brand` theme.

## What does this change?

Hook up checkbox themes

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

![Screenshot 2020-01-10 at 16 01 50](https://user-images.githubusercontent.com/5931528/72167271-c16c6580-33c2-11ea-90e9-8f7b5595ad31.png)
![Screenshot 2020-01-10 at 16 01 55](https://user-images.githubusercontent.com/5931528/72167272-c16c6580-33c2-11ea-86b0-275fc2a708a3.png)
![Screenshot 2020-01-10 at 16 01 59](https://user-images.githubusercontent.com/5931528/72167273-c16c6580-33c2-11ea-9f06-66272daa01a7.png)
![Screenshot 2020-01-10 at 16 02 05](https://user-images.githubusercontent.com/5931528/72167275-c16c6580-33c2-11ea-8726-6c8bb368bb4a.png)


### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
