### PR TITLE
Add supported themes to radio readme

### DIFF
--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -67,3 +67,10 @@ Additional text or a component that appears below the label
 **`boolean`**
 
 Whether radio button is checked
+
+## Supported themes
+
+### Standard
+
+-   `light`
+-   `brand`


### PR DESCRIPTION
## What is the purpose of this change?

We should aim to clarify which themes are supported by which components

## What does this change?

Adds supported themes section to the radio component's readme.
