### PR TITLE
Add supported themes to text-input

### DIFF
--- a/packages/text-input/README.md
+++ b/packages/text-input/README.md
@@ -57,3 +57,9 @@ the width will default to 100% of the field's container.
 **`string`**
 
 Whether error styling should apply to this text input. The string appears as an inline error message.
+
+## Supported themes
+
+### Standard
+
+-   `light`

--- a/packages/text-input/rollup.config.js
+++ b/packages/text-input/rollup.config.js
@@ -22,6 +22,8 @@ module.exports = {
 		"@emotion/css",
 		"@guardian/src-foundations",
 		"@guardian/src-foundations/accessibility",
+		"@guardian/src-foundations/themes",
+		"@guardian/src-foundations/typography",
 	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }


### PR DESCRIPTION
## What is the purpose of this change?

We should make clear which themes are supported by each component.

## What does this change?

- Adds suported themes section to readme
- Explicitly externalise a couple of dependencies to remove rollup warnings
