### PR TITLE
Delete mono theme from link component

### DIFF
--- a/packages/link/README.md
+++ b/packages/link/README.md
@@ -60,4 +60,3 @@ The side of the link on which the icon appears
 -   `light`
 -   `brand`
 -   `brandYellow`
--   `mono`

--- a/packages/link/index.tsx
+++ b/packages/link/index.tsx
@@ -14,7 +14,6 @@ export {
 	linkLight,
 	linkBrand,
 	linkBrandYellow,
-	linkMono,
 } from "@guardian/src-foundations/themes"
 
 export type Priority = "primary" | "secondary"

--- a/packages/link/stories.tsx
+++ b/packages/link/stories.tsx
@@ -7,7 +7,7 @@ import {
 	SvgChevronLeftSingle,
 } from "@guardian/src-svgs"
 import { size } from "@guardian/src-foundations"
-import { Link, linkLight, linkBrandYellow, linkBrand, linkMono } from "./index"
+import { Link, linkLight, linkBrandYellow, linkBrand } from "./index"
 import { ThemeProvider } from "emotion-theming"
 
 /* eslint-disable react/jsx-key */
@@ -89,24 +89,6 @@ priorityYellow.story = {
 				{ default: true },
 				storybookBackgrounds.brandYellow,
 			),
-		],
-	},
-}
-
-export const priorityMono = () => (
-	<ThemeProvider theme={linkMono}>
-		<div css={flexStart}>
-			{priorityLinks.map((button, index) => (
-				<div key={index}>{button}</div>
-			))}
-		</div>
-	</ThemeProvider>
-)
-priorityMono.story = {
-	name: "priority mono",
-	parameters: {
-		backgrounds: [
-			Object.assign({}, { default: true }, storybookBackgrounds.mono),
 		],
 	},
 }


### PR DESCRIPTION
## What is the purpose of this change?

The mono theme is deprecated. We should remove all instances and implementations.

## What does this change?

- un-exposes the mono theme via the link component
- removes mono story from link component stories
