### PR TITLE
Delete mono theme

### DIFF
--- a/packages/foundations/src/palette.ts
+++ b/packages/foundations/src/palette.ts
@@ -85,16 +85,6 @@ const text = {
 	checkbox: neutral[7],
 	checkboxSupporting: neutral[46],
 	checkboxIndeterminate: neutral[46],
-	mono: {
-		primary: neutral[100],
-		secondary: neutral[60],
-		ctaPrimary: neutral[7],
-		ctaSecondary: neutral[100],
-		linkPrimary: neutral[100],
-		linkPrimaryHover: neutral[100],
-		linkSecondary: neutral[100],
-		linkSecondaryHover: neutral[100],
-	},
 	brand: {
 		primary: neutral[100],
 		secondary: neutral[60],
@@ -130,13 +120,6 @@ const background = {
 	ctaSecondaryHover: "#ACC9F7",
 	radioChecked: brand.bright,
 	checkboxChecked: brand.bright,
-	mono: {
-		primary: neutral[7],
-		ctaPrimary: neutral[100],
-		ctaPrimaryHover: neutral[93],
-		ctaSecondary: neutral[46],
-		ctaSecondaryHover: "#5C5C5C",
-	},
 	brand: {
 		primary: brand.main,
 		ctaPrimary: neutral[100],

--- a/packages/foundations/src/themes/index.ts
+++ b/packages/foundations/src/themes/index.ts
@@ -8,7 +8,7 @@ export * from "./text-input"
 import { buttonLight, buttonBrand, buttonBrandYellow } from "./button"
 import { checkboxLight, checkboxBrand } from "./checkbox"
 import { inlineErrorLight, inlineErrorBrand } from "./inline-error"
-import { linkLight, linkBrand, linkBrandYellow, linkMono } from "./link"
+import { linkLight, linkBrand, linkBrandYellow } from "./link"
 import { radioLight, radioBrand } from "./radio"
 import { textInputLight } from "./text-input"
 
@@ -32,8 +32,4 @@ export const brand = {
 export const brandYellow = {
 	...buttonBrandYellow,
 	...linkBrandYellow,
-}
-
-export const mono = {
-	...linkMono,
 }

--- a/packages/foundations/src/themes/link.ts
+++ b/packages/foundations/src/themes/link.ts
@@ -34,15 +34,6 @@ export const linkBrandYellow: { link: LinkTheme } = {
 	},
 }
 
-export const linkMono: { link: LinkTheme } = {
-	link: {
-		textPrimary: palette.text.mono.linkPrimary,
-		textPrimaryHover: palette.text.mono.linkPrimaryHover,
-		textSecondary: palette.text.mono.linkSecondary,
-		textSecondaryHover: palette.text.mono.linkSecondaryHover,
-	},
-}
-
 export const link = {
 	linkLight,
 	linkBrand,

--- a/packages/helpers/storybook-bg.ts
+++ b/packages/helpers/storybook-bg.ts
@@ -13,7 +13,6 @@ const storybookBackgrounds: {
 		name: "brandYellow",
 		value: palette.background.brandYellow.primary,
 	},
-	mono: { name: "mono", value: palette.background.mono.primary },
 }
 
 Object.freeze(storybookBackgrounds)

--- a/packages/helpers/types.ts
+++ b/packages/helpers/types.ts
@@ -1,1 +1,1 @@
-export type ThemeName = "light" | "brand" | "brandYellow" | "mono"
+export type ThemeName = "light" | "brand" | "brandYellow"


### PR DESCRIPTION
## What is the purpose of this change?

The mono theme is deprecated, never to return. We should delete it from all the corners in which it languishes. Nowhere is safe for the mono theme. It is no more.

## What does this change?

- deletes mono-related colours from palette
- deletes mono theme from link theming module
- deletes mono theme from helpers
