### PR TITLE
Add line colours to palette

### DIFF
--- a/packages/foundations/src/palette.ts
+++ b/packages/foundations/src/palette.ts
@@ -161,6 +161,15 @@ const border = {
 		checkboxError: error.bright,
 	},
 }
+const line = {
+	primary: neutral[86],
+	brand: {
+		primary: brand.pastel,
+	},
+	brandYellow: {
+		primary: neutral[7],
+	},
+}
 
 const palette = {
 	brand,
@@ -177,6 +186,7 @@ const palette = {
 	text,
 	background,
 	border,
+	line,
 }
 
 export { palette }


### PR DESCRIPTION
## What is the purpose of this change?

The design system's themes page defines some line colours. These need to be reflected in our foundations.

## What does this change?

Adds some line colours to foundations

## Design


### Accessibility

⛔️ [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
⛔️ [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
