### PR TITLE
Use numbered colour names in text-input

### DIFF
--- a/packages/text-input/styles.ts
+++ b/packages/text-input/styles.ts
@@ -48,7 +48,7 @@ export const text = ({
 
 export const errorInput = css`
 	border: 4px solid ${palette.border.error};
-	color: ${palette.error.main};
+	color: ${palette.text.error};
 `
 
 export const optionalLabel = css`


### PR DESCRIPTION
## What is the purpose of this change?

#180 introduced number-based colour names. Our components should start using these rather than the deprecated names

## What does this change?

Updates the text-input's styles to use more functional colour names
