### PR TITLE
Add support for custom breakpoints to grid

### DIFF
--- a/packages/grid/.gitignore
+++ b/packages/grid/.gitignore
@@ -1,0 +1,3 @@
+# Ignore built files
+*.d.ts
+*.tgz

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -35,13 +35,15 @@ A list of breakpoints at which grid column span may change. GridRow currently
 supports changes at `"mobile"`, `"tablet"`, `"desktop"` and `"wide"` breakpoints.
 Any of these may be omitted.
 
+For best results, breakpoints should be ordered ascending by minimum viewport width.
+
+**Custom breakpoints should be considered experimental. Please tell the Design System Team before you use them**
+
 A custom breakpoint may be specified, which must have the following properties:
 
 -   `width`: the minimum viewport width at which the breakpoint becomes active. This will also
     be the width of the `GridRow` container
 -   `columns`: the number of columns the grid should comprise
-
-For best results, breakpoints should be ordered ascending by minimum viewport width.
 
 ## `GridItem` Props
 

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -29,11 +29,19 @@ const Article = () => (
 
 ### `breakpoints`
 
-**`GridBreakpoints[]`** _= ["mobile", "tablet", "desktop", "wide"]_
+**`Array<GridBreakpoint | CustomBreakpoint>`** _= ["mobile", "tablet", "desktop", "wide"]_
 
 A list of breakpoints at which grid column span may change. GridRow currently
 supports changes at `"mobile"`, `"tablet"`, `"desktop"` and `"wide"` breakpoints.
 Any of these may be omitted.
+
+A custom breakpoint may be specified, which must have the following properties:
+
+-   `width`: the minimum viewport width at which the breakpoint becomes active. This will also
+    be the width of the `GridRow` container
+-   `columns`: the number of columns the grid should comprise
+
+For best results, breakpoints should be ordered ascending by minimum viewport width.
 
 ## `GridItem` Props
 

--- a/packages/grid/data.ts
+++ b/packages/grid/data.ts
@@ -1,0 +1,43 @@
+import { Breakpoint, space, breakpoints } from "@guardian/src-foundations"
+
+export type GridBreakpoint = Extract<
+	Breakpoint,
+	"mobile" | "tablet" | "desktop" | "wide"
+>
+export const gridBreakpoints: readonly GridBreakpoint[] = [
+	"mobile",
+	"tablet",
+	"desktop",
+	"wide",
+] as const
+
+type GridBreakpoints = typeof gridBreakpoints[number]
+
+type GridColumns = {
+	[key in GridBreakpoints]: number
+}
+
+type ContainerWidths = {
+	[key in GridBreakpoints]: string
+}
+
+export type CustomBreakpoint = {
+	width: number
+	columns: number
+}
+
+export const gridColumns: GridColumns = {
+	mobile: 4,
+	tablet: 12,
+	desktop: 12,
+	wide: 16,
+}
+
+export const containerWidths: ContainerWidths = {
+	mobile: "100%",
+	tablet: `${breakpoints.tablet}px`,
+	desktop: `${breakpoints.desktop}px`,
+	wide: `${breakpoints.wide}px`,
+}
+
+export const GUTTER_WIDTH = space[5]

--- a/packages/grid/index.tsx
+++ b/packages/grid/index.tsx
@@ -7,6 +7,7 @@ import {
 	gridRowWide,
 	gridItem,
 	borderRightStyle,
+	createCustomGridRow,
 } from "./styles"
 import { CustomBreakpoint, GridBreakpoint } from "./data"
 import { SerializedStyles } from "@emotion/css"
@@ -59,8 +60,14 @@ const GridRow = ({
 			css={[
 				gridRow,
 				breakpoints.reduce(
-					(acc, breakpoint) =>
-						acc.concat([gridRowBreakpoints[breakpoint]]),
+					(acc, breakpoint) => {
+						const gridRowStyles =
+							typeof breakpoint === "string"
+								? gridRowBreakpoints[breakpoint]
+								: createCustomGridRow(breakpoint)
+
+						return acc.concat([gridRowStyles])
+					},
 					[] as SerializedStyles[],
 				),
 			]}
@@ -86,7 +93,7 @@ const GridItem = ({
 	spans: number[]
 	borderRight?: boolean
 	startingPositions: number[]
-	breakpoints: GridBreakpoint[]
+	breakpoints: Array<GridBreakpoint | CustomBreakpoint>
 	children: JSX.Element | JSX.Element[]
 }) => {
 	return (

--- a/packages/grid/index.tsx
+++ b/packages/grid/index.tsx
@@ -6,9 +6,9 @@ import {
 	gridRowDesktop,
 	gridRowWide,
 	gridItem,
-	GridBreakpoint,
 	borderRightStyle,
 } from "./styles"
+import { CustomBreakpoint, GridBreakpoint } from "./data"
 import { SerializedStyles } from "@emotion/css"
 
 type GridRowBreakpoints = {
@@ -25,7 +25,7 @@ const GridRow = ({
 	breakpoints,
 	children,
 }: {
-	breakpoints: GridBreakpoint[]
+	breakpoints: Array<GridBreakpoint | CustomBreakpoint>
 	children: JSX.Element | JSX.Element[]
 }) => {
 	// Create an array with an entry for each child

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -4,8 +4,8 @@
 	"main": "dist/grid.js",
 	"module": "dist/grid.esm.js",
 	"scripts": {
-		"build": "yarn clean && rollup --config",
-		"clean": "rm -rf dist",
+		"build": "yarn clean && tsc && rollup --config",
+		"clean": "rm -rf dist *.d.ts",
 		"prepublish": "yarn build"
 	},
 	"devDependencies": {
@@ -19,11 +19,14 @@
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
 		"rollup-plugin-commonjs": "^10.0.2",
-		"rollup-plugin-node-resolve": "^5.2.0"
+		"rollup-plugin-node-resolve": "^5.2.0",
+		"typescript": "^3.7.2"
 	},
 	"files": [
 		"index.tsx",
-		"styles.ts"
+		"data.ts",
+		"styles.ts",
+		"*.d.ts"
 	],
 	"peerDependencies": {
 		"@emotion/core": "^10.0.14",

--- a/packages/grid/styles.ts
+++ b/packages/grid/styles.ts
@@ -48,20 +48,25 @@ const gridItemSpans = ({
 	breakpoints,
 	spans,
 }: {
-	breakpoints: GridBreakpoint[]
+	breakpoints: Array<GridBreakpoint | CustomBreakpoint>
 	spans: number[]
 }) => {
 	return breakpoints.reduce((acc, breakpoint, index) => {
+		const mq =
+			typeof breakpoint === "string"
+				? from[breakpoint]
+				: `@media (min-width: ${`${breakpoint.width}px`})`
+
 		if (spans[index] === 0) {
 			return `${acc}
-				${from[breakpoint]} {
+				${mq} {
 					display: none;
 				}
 			`
 		}
 
 		return `${acc}
-			${from[breakpoint]} {
+			${mq} {
 				display: block;
 				grid-column-end: span ${spans[index]};
 				-ms-grid-column-span: ${spans[index]};,
@@ -74,17 +79,26 @@ const gridItemStartingPos = ({
 	breakpoints,
 	startingPositions,
 }: {
-	breakpoints: GridBreakpoint[]
+	breakpoints: Array<GridBreakpoint | CustomBreakpoint>
 	startingPositions: number[]
 }) => {
 	return breakpoints.reduce((acc, breakpoint, index) => {
+		const mq =
+			typeof breakpoint === "string"
+				? from[breakpoint]
+				: `@media (min-width: ${`${breakpoint.width}px`})`
+		const columns =
+			typeof breakpoint === "string"
+				? gridColumns[breakpoint]
+				: breakpoint.columns
+
 		return `${acc}
-			${from[breakpoint]} {
+			${mq} {
 				grid-column-start: ${startingPositions[index]};
 				-ms-grid-column: ${
 					startingPositions[index] > 0
 						? startingPositions[index]
-						: gridColumns[breakpoint] + 2 + startingPositions[index]
+						: columns + 2 + startingPositions[index]
 				};
 			}
 		`
@@ -96,7 +110,7 @@ const gridItem = ({
 	spans,
 	startingPositions,
 }: {
-	breakpoints: GridBreakpoint[]
+	breakpoints: Array<GridBreakpoint | CustomBreakpoint>
 	spans: number[]
 	startingPositions: number[]
 }) => css`
@@ -115,6 +129,24 @@ const borderRightStyle = css`
 	margin-right: ${-GUTTER_WIDTH / 2}px;
 `
 
+const createCustomGridRow = ({
+	width,
+	columns,
+}: {
+	width: number
+	columns: number
+}) => {
+	const msGridColumns = `-ms-grid-columns: (minmax(0, 1fr))[${columns}]`
+
+	return css`
+		@media (min-width: ${`${width}px`}) {
+			width: ${width}px;
+			grid-template-columns: repeat(${columns}, 1fr);
+			${msGridColumns};
+		}
+	`
+}
+
 export {
 	gridRow,
 	gridRowMobile,
@@ -123,4 +155,5 @@ export {
 	gridRowWide,
 	gridItem,
 	borderRightStyle,
+	createCustomGridRow,
 }

--- a/packages/grid/styles.ts
+++ b/packages/grid/styles.ts
@@ -1,47 +1,14 @@
 import { css } from "@emotion/core"
-import {
-	Breakpoint,
-	space,
-	breakpoints,
-	palette,
-} from "@guardian/src-foundations"
+import { space, palette } from "@guardian/src-foundations"
 import { from } from "@guardian/src-foundations/mq"
-
-type GridBreakpoint = Extract<
-	Breakpoint,
-	"mobile" | "tablet" | "desktop" | "wide"
->
-const gridBreakpoints: readonly GridBreakpoint[] = [
-	"mobile",
-	"tablet",
-	"desktop",
-	"wide",
-] as const
-type GridBreakpoints = typeof gridBreakpoints[number]
-
-type GridColumns = {
-	[key in GridBreakpoints]: number
-}
-
-type ContainerWidths = {
-	[key in GridBreakpoints]: string
-}
-
-const gridColumns: GridColumns = {
-	mobile: 4,
-	tablet: 12,
-	desktop: 12,
-	wide: 16,
-}
-
-const containerWidths: ContainerWidths = {
-	mobile: "100%",
-	tablet: `${breakpoints.tablet}px`,
-	desktop: `${breakpoints.desktop}px`,
-	wide: `${breakpoints.wide}px`,
-}
-
-const GUTTER_WIDTH = space[5]
+import {
+	GUTTER_WIDTH,
+	gridBreakpoints,
+	gridColumns,
+	containerWidths,
+	CustomBreakpoint,
+	GridBreakpoint,
+} from "./data"
 
 const gridRow = css`
 	@supports (display: grid) {
@@ -155,6 +122,5 @@ export {
 	gridRowDesktop,
 	gridRowWide,
 	gridItem,
-	GridBreakpoint,
 	borderRightStyle,
 }

--- a/packages/grid/styles.ts
+++ b/packages/grid/styles.ts
@@ -46,8 +46,8 @@ const [
 
 const mqForBreakpoint = (breakpoint: GridBreakpoint | CustomBreakpoint) => {
 	return typeof breakpoint === "string"
-	? from[breakpoint]
-	: `@media (min-width: ${`${breakpoint.width}px`})`
+		? from[breakpoint]
+		: `@media (min-width: ${`${breakpoint.width}px`})`
 }
 
 const gridItemSpans = ({
@@ -139,7 +139,7 @@ const createCustomGridRow = ({
 	const msGridColumns = `-ms-grid-columns: (minmax(0, 1fr))[${columns}]`
 
 	return css`
-		${mqForBreakpoint({width, columns})} {
+		${mqForBreakpoint({ width, columns })} {
 			width: ${width}px;
 			grid-template-columns: repeat(${columns}, 1fr);
 			${msGridColumns};

--- a/packages/grid/styles.ts
+++ b/packages/grid/styles.ts
@@ -44,6 +44,12 @@ const [
 	`
 })
 
+const mqForBreakpoint = (breakpoint: GridBreakpoint | CustomBreakpoint) => {
+	return typeof breakpoint === "string"
+	? from[breakpoint]
+	: `@media (min-width: ${`${breakpoint.width}px`})`
+}
+
 const gridItemSpans = ({
 	breakpoints,
 	spans,
@@ -52,10 +58,7 @@ const gridItemSpans = ({
 	spans: number[]
 }) => {
 	return breakpoints.reduce((acc, breakpoint, index) => {
-		const mq =
-			typeof breakpoint === "string"
-				? from[breakpoint]
-				: `@media (min-width: ${`${breakpoint.width}px`})`
+		const mq = mqForBreakpoint(breakpoint)
 
 		if (spans[index] === 0) {
 			return `${acc}
@@ -83,10 +86,7 @@ const gridItemStartingPos = ({
 	startingPositions: number[]
 }) => {
 	return breakpoints.reduce((acc, breakpoint, index) => {
-		const mq =
-			typeof breakpoint === "string"
-				? from[breakpoint]
-				: `@media (min-width: ${`${breakpoint.width}px`})`
+		const mq = mqForBreakpoint(breakpoint)
 		const columns =
 			typeof breakpoint === "string"
 				? gridColumns[breakpoint]
@@ -139,7 +139,7 @@ const createCustomGridRow = ({
 	const msGridColumns = `-ms-grid-columns: (minmax(0, 1fr))[${columns}]`
 
 	return css`
-		@media (min-width: ${`${width}px`}) {
+		${mqForBreakpoint({width, columns})} {
 			width: ${width}px;
 			grid-template-columns: repeat(${columns}, 1fr);
 			${msGridColumns};

--- a/packages/grid/tsconfig.json
+++ b/packages/grid/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"compilerOptions": {
+		"outDir": ".",
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		"jsx": "preserve",
+		"esModuleInterop": true
+	},
+	"exclude": ["node_modules"]
+}


### PR DESCRIPTION
## What is the purpose of this change?

We don't want to hardcore every breakpoint used by every project into the Grid component, but the sensible defaults we provide are not enough. We should allow consumers to define their own breakpoints.

This API will be published as an alpha release and should be considered experimental!

## What does this change?

The `breakpoints` prop passed to `GridRow` may now include `CustomBreakpoint` objects. These take the following properties:

-   `width`: the minimum viewport width at which the breakpoint becomes active. This will also
    be the width of the `GridRow` container
-   `columns`: the number of columns the grid should comprise

Usage example:

```tsx
<GridRow
  breakpoints={[
    'mobile',
    'desktop',
    { width: 1140, columns: 14 },
    'wide',
  ]}
>
  <GridItem spans={[0, 0, 3, 3]}>
    <LeftColumn/>
  </GridItem>
  <GridItem spans={[4, 8, 7, 9]}>
    <Main/>
  </GridItem>
  <GridItem spans={[0, 4, 4, 4]}>
    <RightColumn/>
  </GridItem>
```
