### PR TITLE
Use error border colour for error border

### DIFF
--- a/packages/radio/styles.ts
+++ b/packages/radio/styles.ts
@@ -114,5 +114,5 @@ export const vertical = css`
 export const errorRadio = ({
 	radio,
 }: { radio: RadioTheme } = radioLight) => css`
-	border: 4px solid ${radio.textError};
+	border: 4px solid ${radio.borderError};
 `


### PR DESCRIPTION
## What is the purpose of this change?

We're using a text colour for the error border colour currently

## What does this change?

Switch to using `borderError` instead of `textError`. Note `textError` is no longer being used and can safely be deleted.
