### PR TITLE
Use component-specific theme colours

### DIFF
--- a/packages/text-input/index.tsx
+++ b/packages/text-input/index.tsx
@@ -25,7 +25,11 @@ const widths: {
 }
 
 const SupportingText = ({ children }: { children: ReactNode }) => {
-	return <div css={supportingText}>{children}</div>
+	return (
+		<div css={theme => supportingText(theme.textInput && theme)}>
+			{children}
+		</div>
+	)
 }
 
 const TextInput = ({
@@ -48,7 +52,15 @@ const TextInput = ({
 		<label>
 			<div css={theme => text(theme.textInput && theme)}>
 				{labelText}{" "}
-				{optional ? <span css={optionalLabel}>Optional</span> : ""}
+				{optional ? (
+					<span
+						css={theme => optionalLabel(theme.textInput && theme)}
+					>
+						Optional
+					</span>
+				) : (
+					""
+				)}
 			</div>
 			{supporting ? <SupportingText>{supporting}</SupportingText> : ""}
 			{error && <InlineError>{error}</InlineError>}
@@ -56,7 +68,7 @@ const TextInput = ({
 				css={theme => [
 					width ? widths[width] : widthFluid,
 					textInput(theme.textInput && theme),
-					error ? errorInput : "",
+					error ? errorInput(theme.textInput && theme) : "",
 				]}
 				{...props}
 			/>

--- a/packages/text-input/styles.ts
+++ b/packages/text-input/styles.ts
@@ -1,5 +1,5 @@
 import { css } from "@emotion/core"
-import { size, palette, space } from "@guardian/src-foundations"
+import { size, space } from "@guardian/src-foundations"
 import { textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
 import {
@@ -14,7 +14,7 @@ export const textInput = ({
 	${textSans.medium()};
 	color: ${textInput.textInput};
 	background-color: ${textInput.backgroundInput};
-	border: 2px solid ${palette.border.textInput};
+	border: 2px solid ${textInput.border};
 	padding: 0 ${space[2]}px;
 
 	&:focus {
@@ -46,19 +46,25 @@ export const text = ({
 	margin-bottom: ${space[1]}px;
 `
 
-export const errorInput = css`
-	border: 4px solid ${palette.border.error};
-	color: ${palette.text.error};
+export const errorInput = ({
+	textInput,
+}: { textInput: TextInputTheme } = textInputLight) => css`
+	border: 4px solid ${textInput.borderError};
+	color: ${textInput.textError};
 `
 
-export const optionalLabel = css`
+export const optionalLabel = ({
+	textInput,
+}: { textInput: TextInputTheme } = textInputLight) => css`
 	${textSans.small()};
-	color: ${palette.text.secondary};
+	color: ${textInput.textOptionalLabel};
 	font-style: italic;
 `
 
-export const supportingText = css`
+export const supportingText = ({
+	textInput,
+}: { textInput: TextInputTheme } = textInputLight) => css`
 	${textSans.small()};
-	color: ${palette.text.secondary};
+	color: ${textInput.textSupporting};
 	margin-bottom: ${space[1]}px;
 `


### PR DESCRIPTION
## What is the purpose of this change?

We're using more general colours within the text-input component styles, when we should be using theme-specific colours.

## What does this change?

Switch to using theme-specific colours that are now exposed by the text-input theme.
