### PR TITLE
Remove unused colours from radio theme

### DIFF
--- a/packages/foundations/src/themes/radio.ts
+++ b/packages/foundations/src/themes/radio.ts
@@ -11,8 +11,6 @@ export type RadioTheme = {
 	backgroundChecked: string
 	text: string
 	textSupporting: string
-	// TODO: remove textError as it is not used
-	textError: string
 	borderError: string
 }
 
@@ -26,8 +24,6 @@ export const radioLight: {
 		backgroundChecked: palette.background.radioChecked,
 		text: palette.text.radio,
 		textSupporting: palette.text.radioSupporting,
-		// TODO: remove textError as it is not used
-		textError: palette.border.radioError,
 		borderError: palette.border.radioError,
 	},
 	...inlineErrorLight,
@@ -43,8 +39,6 @@ export const radioBrand: {
 		backgroundChecked: palette.background.brand.radioChecked,
 		text: palette.text.brand.radio,
 		textSupporting: palette.text.brand.radioSupporting,
-		// TODO: remove textError as it is not used
-		textError: palette.border.brand.radioError,
 		borderError: palette.border.brand.radioError,
 	},
 	...inlineErrorBrand,


### PR DESCRIPTION
## What is the purpose of this change?

We no longer use `textError` so it can safely be removed

## What does this change?

Remove `textError` from radio theme
