### PR TITLE
Expose new theme names

### DIFF
--- a/packages/foundations/src/palette/background.ts
+++ b/packages/foundations/src/palette/background.ts
@@ -1,15 +1,5 @@
 import { neutral, brand, brandYellow } from "./global"
 
-const brandDefault = {
-	primary: brand[400],
-	buttonPrimary: neutral[100],
-	buttonPrimaryHover: "#E0E0E0",
-	buttonSecondary: brand[600],
-	buttonSecondaryHover: "#234B8A",
-	checkboxChecked: neutral[100],
-	radioChecked: neutral[100],
-}
-
 const brandAlt = {
 	primary: brandYellow[400],
 	buttonPrimary: neutral[7],
@@ -27,9 +17,16 @@ export const background = {
 	checkboxChecked: brand[500],
 	radioChecked: brand[500],
 	textInput: neutral[100],
-	brandDefault,
+	brand: {
+		primary: brand[400],
+		buttonPrimary: neutral[100],
+		buttonPrimaryHover: "#E0E0E0",
+		buttonSecondary: brand[600],
+		buttonSecondaryHover: "#234B8A",
+		checkboxChecked: neutral[100],
+		radioChecked: neutral[100],
+	},
 	brandAlt,
 	// continue to expose legacy theme names
-	brand: brandDefault,
 	brandYellow: brandAlt,
 }

--- a/packages/foundations/src/palette/background.ts
+++ b/packages/foundations/src/palette/background.ts
@@ -1,5 +1,23 @@
 import { neutral, brand, brandYellow } from "./global"
 
+const brandDefault = {
+	primary: brand[400],
+	buttonPrimary: neutral[100],
+	buttonPrimaryHover: "#E0E0E0",
+	buttonSecondary: brand[600],
+	buttonSecondaryHover: "#234B8A",
+	checkboxChecked: neutral[100],
+	radioChecked: neutral[100],
+}
+
+const brandAlt = {
+	primary: brandYellow[400],
+	buttonPrimary: neutral[7],
+	buttonPrimaryHover: "#454545",
+	buttonSecondary: brandYellow[300],
+	buttonSecondaryHover: "#F2AE00",
+}
+
 export const background = {
 	primary: neutral[100],
 	buttonPrimary: brand[400],
@@ -9,20 +27,9 @@ export const background = {
 	checkboxChecked: brand[500],
 	radioChecked: brand[500],
 	textInput: neutral[100],
-	brand: {
-		primary: brand[400],
-		buttonPrimary: neutral[100],
-		buttonPrimaryHover: "#E0E0E0",
-		buttonSecondary: brand[600],
-		buttonSecondaryHover: "#234B8A",
-		checkboxChecked: neutral[100],
-		radioChecked: neutral[100],
-	},
-	brandYellow: {
-		primary: brandYellow[400],
-		buttonPrimary: neutral[7],
-		buttonPrimaryHover: "#454545",
-		buttonSecondary: brandYellow[300],
-		buttonSecondaryHover: "#F2AE00",
-	},
+	brandDefault,
+	brandAlt,
+	// continue to expose legacy theme names
+	brand: brandDefault,
+	brandYellow: brandAlt,
 }

--- a/packages/foundations/src/palette/border.ts
+++ b/packages/foundations/src/palette/border.ts
@@ -1,5 +1,16 @@
 import { neutral, error, brand, sport } from "./global"
 
+const brandDefault = {
+	error: error[500],
+	checkbox: brand[800],
+	checkboxHover: neutral[100],
+	checkboxChecked: neutral[100],
+	checkboxError: error[500],
+	radio: brand[800],
+	radioHover: neutral[100],
+	radioError: error[500],
+}
+
 export const border = {
 	primary: neutral[60],
 	secondary: neutral[86],
@@ -14,14 +25,7 @@ export const border = {
 	radioError: error[400],
 	textInput: neutral[60],
 	textInputError: error[400],
-	brand: {
-		error: error[500],
-		checkbox: brand[800],
-		checkboxHover: neutral[100],
-		checkboxChecked: neutral[100],
-		checkboxError: error[500],
-		radio: brand[800],
-		radioHover: neutral[100],
-		radioError: error[500],
-	},
+	brandDefault,
+	// continue to expose legacy theme names
+	brand: brandDefault,
 }

--- a/packages/foundations/src/palette/border.ts
+++ b/packages/foundations/src/palette/border.ts
@@ -1,16 +1,5 @@
 import { neutral, error, brand, sport } from "./global"
 
-const brandDefault = {
-	error: error[500],
-	checkbox: brand[800],
-	checkboxHover: neutral[100],
-	checkboxChecked: neutral[100],
-	checkboxError: error[500],
-	radio: brand[800],
-	radioHover: neutral[100],
-	radioError: error[500],
-}
-
 export const border = {
 	primary: neutral[60],
 	secondary: neutral[86],
@@ -25,7 +14,14 @@ export const border = {
 	radioError: error[400],
 	textInput: neutral[60],
 	textInputError: error[400],
-	brandDefault,
-	// continue to expose legacy theme names
-	brand: brandDefault,
+	brand: {
+		error: error[500],
+		checkbox: brand[800],
+		checkboxHover: neutral[100],
+		checkboxChecked: neutral[100],
+		checkboxError: error[500],
+		radio: brand[800],
+		radioHover: neutral[100],
+		radioError: error[500],
+	},
 }

--- a/packages/foundations/src/palette/line.ts
+++ b/packages/foundations/src/palette/line.ts
@@ -1,11 +1,16 @@
 import { neutral, brand } from "./global"
 
+const brandDefault = {
+	primary: brand[600],
+}
+const brandAlt = {
+	primary: neutral[7],
+}
 export const line = {
 	primary: neutral[86],
-	brand: {
-		primary: brand[600],
-	},
-	brandYellow: {
-		primary: neutral[7],
-	},
+	brandDefault,
+	brandAlt,
+	// continue to expose legacy theme names
+	brand: brandDefault,
+	brandYellow: brandAlt,
 }

--- a/packages/foundations/src/palette/line.ts
+++ b/packages/foundations/src/palette/line.ts
@@ -1,16 +1,14 @@
 import { neutral, brand } from "./global"
 
-const brandDefault = {
-	primary: brand[600],
-}
 const brandAlt = {
 	primary: neutral[7],
 }
 export const line = {
 	primary: neutral[86],
-	brandDefault,
+	brand: {
+		primary: brand[600],
+	},
 	brandAlt,
 	// continue to expose legacy theme names
-	brand: brandDefault,
 	brandYellow: brandAlt,
 }

--- a/packages/foundations/src/palette/text.ts
+++ b/packages/foundations/src/palette/text.ts
@@ -1,19 +1,5 @@
 import { neutral, error, brand } from "./global"
 
-const brandDefault = {
-	primary: neutral[100],
-	secondary: brand[800],
-	error: error[500],
-	buttonPrimary: brand[400],
-	buttonSecondary: neutral[100],
-	checkbox: neutral[100],
-	checkboxSupporting: brand[800],
-	checkboxIndeterminate: brand[800],
-	linkPrimary: neutral[100],
-	linkPrimaryHover: neutral[100],
-	radio: neutral[100],
-	radioSupporting: brand[800],
-}
 const brandAlt = {
 	primary: neutral[7],
 	secondary: neutral[60],
@@ -42,9 +28,21 @@ export const text = {
 	textInputOptionalLabel: neutral[46],
 	textInputSupporting: neutral[46],
 	textInputError: error[400],
-	brandDefault,
+	brand: {
+		primary: neutral[100],
+		secondary: brand[800],
+		error: error[500],
+		buttonPrimary: brand[400],
+		buttonSecondary: neutral[100],
+		checkbox: neutral[100],
+		checkboxSupporting: brand[800],
+		checkboxIndeterminate: brand[800],
+		linkPrimary: neutral[100],
+		linkPrimaryHover: neutral[100],
+		radio: neutral[100],
+		radioSupporting: brand[800],
+	},
 	brandAlt,
 	// continue to expose legacy theme names
-	brand: brandDefault,
 	brandYellow: brandAlt,
 }

--- a/packages/foundations/src/palette/text.ts
+++ b/packages/foundations/src/palette/text.ts
@@ -1,5 +1,27 @@
 import { neutral, error, brand } from "./global"
 
+const brandDefault = {
+	primary: neutral[100],
+	secondary: brand[800],
+	error: error[500],
+	buttonPrimary: brand[400],
+	buttonSecondary: neutral[100],
+	checkbox: neutral[100],
+	checkboxSupporting: brand[800],
+	checkboxIndeterminate: brand[800],
+	linkPrimary: neutral[100],
+	linkPrimaryHover: neutral[100],
+	radio: neutral[100],
+	radioSupporting: brand[800],
+}
+const brandAlt = {
+	primary: neutral[7],
+	secondary: neutral[60],
+	buttonPrimary: neutral[100],
+	buttonSecondary: neutral[7],
+	linkPrimary: neutral[7],
+	linkPrimaryHover: neutral[7],
+}
 export const text = {
 	primary: neutral[7],
 	secondary: neutral[46],
@@ -20,26 +42,9 @@ export const text = {
 	textInputOptionalLabel: neutral[46],
 	textInputSupporting: neutral[46],
 	textInputError: error[400],
-	brand: {
-		primary: neutral[100],
-		secondary: brand[800],
-		error: error[500],
-		buttonPrimary: brand[400],
-		buttonSecondary: neutral[100],
-		checkbox: neutral[100],
-		checkboxSupporting: brand[800],
-		checkboxIndeterminate: brand[800],
-		linkPrimary: neutral[100],
-		linkPrimaryHover: neutral[100],
-		radio: neutral[100],
-		radioSupporting: brand[800],
-	},
-	brandYellow: {
-		primary: neutral[7],
-		secondary: neutral[60],
-		buttonPrimary: neutral[100],
-		buttonSecondary: neutral[7],
-		linkPrimary: neutral[7],
-		linkPrimaryHover: neutral[7],
-	},
+	brandDefault,
+	brandAlt,
+	// continue to expose legacy theme names
+	brand: brandDefault,
+	brandYellow: brandAlt,
 }

--- a/packages/foundations/src/themes/button.ts
+++ b/packages/foundations/src/themes/button.ts
@@ -12,7 +12,7 @@ export type ButtonTheme = {
 	backgroundTertiary?: string
 }
 
-export const buttonLight: { button: ButtonTheme } = {
+export const buttonDefault: { button: ButtonTheme } = {
 	button: {
 		textPrimary: palette.text.buttonPrimary,
 		backgroundPrimary: palette.background.buttonPrimary,
@@ -25,35 +25,45 @@ export const buttonLight: { button: ButtonTheme } = {
 	},
 }
 
-export const buttonBrand: { button: ButtonTheme } = {
+export const buttonBrandDefault: { button: ButtonTheme } = {
 	button: {
-		textPrimary: palette.text.brand.buttonPrimary,
-		backgroundPrimary: palette.background.brand.buttonPrimary,
-		backgroundPrimaryHover: palette.background.brand.buttonPrimaryHover,
-		textSecondary: palette.text.brand.buttonSecondary,
-		backgroundSecondary: palette.background.brand.buttonSecondary,
-		backgroundSecondaryHover: palette.background.brand.buttonSecondaryHover,
-		textTertiary: palette.text.brand.buttonSecondary,
-		backgroundTertiary: palette.background.brand.primary,
+		textPrimary: palette.text.brandDefault.buttonPrimary,
+		backgroundPrimary: palette.background.brandDefault.buttonPrimary,
+		backgroundPrimaryHover:
+			palette.background.brandDefault.buttonPrimaryHover,
+		textSecondary: palette.text.brandDefault.buttonSecondary,
+		backgroundSecondary: palette.background.brandDefault.buttonSecondary,
+		backgroundSecondaryHover:
+			palette.background.brandDefault.buttonSecondaryHover,
+		textTertiary: palette.text.brandDefault.buttonSecondary,
+		backgroundTertiary: palette.background.brandDefault.primary,
 	},
 }
 
-export const buttonBrandYellow: { button: ButtonTheme } = {
+export const buttonBrandAlt: { button: ButtonTheme } = {
 	button: {
-		textPrimary: palette.text.brandYellow.buttonPrimary,
-		backgroundPrimary: palette.background.brandYellow.buttonPrimary,
-		backgroundPrimaryHover:
-			palette.background.brandYellow.buttonPrimaryHover,
-		textSecondary: palette.text.brandYellow.buttonSecondary,
-		backgroundSecondary: palette.background.brandYellow.buttonSecondary,
+		textPrimary: palette.text.brandAlt.buttonPrimary,
+		backgroundPrimary: palette.background.brandAlt.buttonPrimary,
+		backgroundPrimaryHover: palette.background.brandAlt.buttonPrimaryHover,
+		textSecondary: palette.text.brandAlt.buttonSecondary,
+		backgroundSecondary: palette.background.brandAlt.buttonSecondary,
 		backgroundSecondaryHover:
-			palette.background.brandYellow.buttonSecondaryHover,
-		textTertiary: palette.text.brandYellow.buttonSecondary,
-		backgroundTertiary: palette.background.brandYellow.primary,
+			palette.background.brandAlt.buttonSecondaryHover,
+		textTertiary: palette.text.brandAlt.buttonSecondary,
+		backgroundTertiary: palette.background.brandAlt.primary,
 	},
 }
+
+// continue to expose legacy theme names
+export const buttonLight = buttonDefault
+export const buttonBrand = buttonBrandDefault
+export const buttonBrandYellow = buttonBrandAlt
 
 export const button = {
+	buttonDefault,
+	buttonBrandDefault,
+	buttonBrandAlt,
+	// continue to expose legacy theme names
 	buttonLight,
 	buttonBrand,
 	buttonBrandYellow,

--- a/packages/foundations/src/themes/button.ts
+++ b/packages/foundations/src/themes/button.ts
@@ -55,12 +55,3 @@ export const buttonBrandAlt: { button: ButtonTheme } = {
 // continue to expose legacy theme names
 export const buttonLight = buttonDefault
 export const buttonBrandYellow = buttonBrandAlt
-
-export const button = {
-	buttonDefault,
-	buttonBrand,
-	buttonBrandAlt,
-	// continue to expose legacy theme names
-	buttonLight,
-	buttonBrandYellow,
-}

--- a/packages/foundations/src/themes/button.ts
+++ b/packages/foundations/src/themes/button.ts
@@ -25,18 +25,16 @@ export const buttonDefault: { button: ButtonTheme } = {
 	},
 }
 
-export const buttonBrandDefault: { button: ButtonTheme } = {
+export const buttonBrand: { button: ButtonTheme } = {
 	button: {
-		textPrimary: palette.text.brandDefault.buttonPrimary,
-		backgroundPrimary: palette.background.brandDefault.buttonPrimary,
-		backgroundPrimaryHover:
-			palette.background.brandDefault.buttonPrimaryHover,
-		textSecondary: palette.text.brandDefault.buttonSecondary,
-		backgroundSecondary: palette.background.brandDefault.buttonSecondary,
-		backgroundSecondaryHover:
-			palette.background.brandDefault.buttonSecondaryHover,
-		textTertiary: palette.text.brandDefault.buttonSecondary,
-		backgroundTertiary: palette.background.brandDefault.primary,
+		textPrimary: palette.text.brand.buttonPrimary,
+		backgroundPrimary: palette.background.brand.buttonPrimary,
+		backgroundPrimaryHover: palette.background.brand.buttonPrimaryHover,
+		textSecondary: palette.text.brand.buttonSecondary,
+		backgroundSecondary: palette.background.brand.buttonSecondary,
+		backgroundSecondaryHover: palette.background.brand.buttonSecondaryHover,
+		textTertiary: palette.text.brand.buttonSecondary,
+		backgroundTertiary: palette.background.brand.primary,
 	},
 }
 
@@ -56,15 +54,13 @@ export const buttonBrandAlt: { button: ButtonTheme } = {
 
 // continue to expose legacy theme names
 export const buttonLight = buttonDefault
-export const buttonBrand = buttonBrandDefault
 export const buttonBrandYellow = buttonBrandAlt
 
 export const button = {
 	buttonDefault,
-	buttonBrandDefault,
+	buttonBrand,
 	buttonBrandAlt,
 	// continue to expose legacy theme names
 	buttonLight,
-	buttonBrand,
 	buttonBrandYellow,
 }

--- a/packages/foundations/src/themes/checkbox.ts
+++ b/packages/foundations/src/themes/checkbox.ts
@@ -1,7 +1,7 @@
 import { palette } from "../index"
 import {
 	inlineErrorDefault,
-	inlineErrorBrandDefault,
+	inlineErrorBrand,
 	InlineErrorTheme,
 } from "./inline-error"
 
@@ -33,23 +33,22 @@ export const checkboxDefault: {
 	...inlineErrorDefault,
 }
 
-export const checkboxBrandDefault: {
+export const checkboxBrand: {
 	checkbox: CheckboxTheme
 	inlineError: InlineErrorTheme
 } = {
 	checkbox: {
-		border: palette.border.brandDefault.checkbox,
-		borderHover: palette.border.brandDefault.checkboxHover,
-		borderChecked: palette.border.brandDefault.checkboxChecked,
-		borderError: palette.border.brandDefault.checkboxError,
-		backgroundChecked: palette.background.brandDefault.checkboxChecked,
-		text: palette.text.brandDefault.checkbox,
-		textSupporting: palette.text.brandDefault.checkboxSupporting,
-		textIndeterminate: palette.text.brandDefault.checkboxIndeterminate,
+		border: palette.border.brand.checkbox,
+		borderHover: palette.border.brand.checkboxHover,
+		borderChecked: palette.border.brand.checkboxChecked,
+		borderError: palette.border.brand.checkboxError,
+		backgroundChecked: palette.background.brand.checkboxChecked,
+		text: palette.text.brand.checkbox,
+		textSupporting: palette.text.brand.checkboxSupporting,
+		textIndeterminate: palette.text.brand.checkboxIndeterminate,
 	},
-	...inlineErrorBrandDefault,
+	...inlineErrorBrand,
 }
 
 // continue to expose legacy theme names
 export const checkboxLight = checkboxDefault
-export const checkboxBrand = checkboxBrandDefault

--- a/packages/foundations/src/themes/checkbox.ts
+++ b/packages/foundations/src/themes/checkbox.ts
@@ -1,7 +1,7 @@
 import { palette } from "../index"
 import {
-	inlineErrorLight,
-	inlineErrorBrand,
+	inlineErrorDefault,
+	inlineErrorBrandDefault,
 	InlineErrorTheme,
 } from "./inline-error"
 
@@ -16,7 +16,7 @@ export type CheckboxTheme = {
 	textIndeterminate: string
 }
 
-export const checkboxLight: {
+export const checkboxDefault: {
 	checkbox: CheckboxTheme
 	inlineError: InlineErrorTheme
 } = {
@@ -30,22 +30,26 @@ export const checkboxLight: {
 		textSupporting: palette.text.checkboxSupporting,
 		textIndeterminate: palette.text.checkboxIndeterminate,
 	},
-	...inlineErrorLight,
+	...inlineErrorDefault,
 }
 
-export const checkboxBrand: {
+export const checkboxBrandDefault: {
 	checkbox: CheckboxTheme
 	inlineError: InlineErrorTheme
 } = {
 	checkbox: {
-		border: palette.border.brand.checkbox,
-		borderHover: palette.border.brand.checkboxHover,
-		borderChecked: palette.border.brand.checkboxChecked,
-		borderError: palette.border.brand.checkboxError,
-		backgroundChecked: palette.background.brand.checkboxChecked,
-		text: palette.text.brand.checkbox,
-		textSupporting: palette.text.brand.checkboxSupporting,
-		textIndeterminate: palette.text.brand.checkboxIndeterminate,
+		border: palette.border.brandDefault.checkbox,
+		borderHover: palette.border.brandDefault.checkboxHover,
+		borderChecked: palette.border.brandDefault.checkboxChecked,
+		borderError: palette.border.brandDefault.checkboxError,
+		backgroundChecked: palette.background.brandDefault.checkboxChecked,
+		text: palette.text.brandDefault.checkbox,
+		textSupporting: palette.text.brandDefault.checkboxSupporting,
+		textIndeterminate: palette.text.brandDefault.checkboxIndeterminate,
 	},
-	...inlineErrorBrand,
+	...inlineErrorBrandDefault,
 }
+
+// continue to expose legacy theme names
+export const checkboxLight = checkboxDefault
+export const checkboxBrand = checkboxBrandDefault

--- a/packages/foundations/src/themes/index.ts
+++ b/packages/foundations/src/themes/index.ts
@@ -5,14 +5,50 @@ export * from "./link"
 export * from "./radio"
 export * from "./text-input"
 
-import { buttonLight, buttonBrand, buttonBrandYellow } from "./button"
-import { checkboxLight, checkboxBrand } from "./checkbox"
-import { inlineErrorLight, inlineErrorBrand } from "./inline-error"
-import { linkLight, linkBrand, linkBrandYellow } from "./link"
-import { radioLight, radioBrand } from "./radio"
-import { textInputLight } from "./text-input"
+import {
+	buttonLight,
+	buttonBrand,
+	buttonBrandYellow,
+	buttonDefault,
+	buttonBrandDefault,
+	buttonBrandAlt,
+} from "./button"
+import {
+	checkboxLight,
+	checkboxBrand,
+	checkboxDefault,
+	checkboxBrandDefault,
+} from "./checkbox"
+import {
+	inlineErrorLight,
+	inlineErrorBrand,
+	inlineErrorDefault,
+	inlineErrorBrandDefault,
+} from "./inline-error"
+import {
+	linkLight,
+	linkBrand,
+	linkBrandYellow,
+	linkDefault,
+	linkBrandDefault,
+	linkBrandAlt,
+} from "./link"
+import {
+	radioLight,
+	radioBrand,
+	radioDefault,
+	radioBrandDefault,
+} from "./radio"
+import { textInputLight, textInputDefault } from "./text-input"
 
-export const light = {
+export const defaultTheme = {
+	...buttonDefault,
+	...checkboxDefault,
+	...inlineErrorDefault,
+	...linkDefault,
+	...radioDefault,
+	...textInputDefault,
+	// continue to expose legacy theme names
 	...buttonLight,
 	...checkboxLight,
 	...inlineErrorLight,
@@ -21,7 +57,13 @@ export const light = {
 	...textInputLight,
 }
 
-export const brand = {
+export const brandDefault = {
+	...buttonBrandDefault,
+	...checkboxBrandDefault,
+	...inlineErrorBrandDefault,
+	...linkBrandDefault,
+	...radioBrandDefault,
+	// continue to expose legacy theme names
 	...buttonBrand,
 	...checkboxBrand,
 	...inlineErrorBrand,
@@ -29,7 +71,15 @@ export const brand = {
 	...radioBrand,
 }
 
-export const brandYellow = {
+export const brandAlt = {
+	...buttonBrandAlt,
+	...linkBrandAlt,
+	// continue to expose legacy theme names
 	...buttonBrandYellow,
 	...linkBrandYellow,
 }
+
+// continue to expose legacy theme names
+export const light = defaultTheme
+export const brand = brandDefault
+export const brandYellow = brandAlt

--- a/packages/foundations/src/themes/index.ts
+++ b/packages/foundations/src/themes/index.ts
@@ -10,35 +10,22 @@ import {
 	buttonBrand,
 	buttonBrandYellow,
 	buttonDefault,
-	buttonBrandDefault,
 	buttonBrandAlt,
 } from "./button"
-import {
-	checkboxLight,
-	checkboxBrand,
-	checkboxDefault,
-	checkboxBrandDefault,
-} from "./checkbox"
+import { checkboxLight, checkboxBrand, checkboxDefault } from "./checkbox"
 import {
 	inlineErrorLight,
 	inlineErrorBrand,
 	inlineErrorDefault,
-	inlineErrorBrandDefault,
 } from "./inline-error"
 import {
 	linkLight,
 	linkBrand,
 	linkBrandYellow,
 	linkDefault,
-	linkBrandDefault,
 	linkBrandAlt,
 } from "./link"
-import {
-	radioLight,
-	radioBrand,
-	radioDefault,
-	radioBrandDefault,
-} from "./radio"
+import { radioLight, radioBrand, radioDefault } from "./radio"
 import { textInputLight, textInputDefault } from "./text-input"
 
 export const defaultTheme = {
@@ -57,13 +44,7 @@ export const defaultTheme = {
 	...textInputLight,
 }
 
-export const brandDefault = {
-	...buttonBrandDefault,
-	...checkboxBrandDefault,
-	...inlineErrorBrandDefault,
-	...linkBrandDefault,
-	...radioBrandDefault,
-	// continue to expose legacy theme names
+export const brand = {
 	...buttonBrand,
 	...checkboxBrand,
 	...inlineErrorBrand,
@@ -81,5 +62,4 @@ export const brandAlt = {
 
 // continue to expose legacy theme names
 export const light = defaultTheme
-export const brand = brandDefault
 export const brandYellow = brandAlt

--- a/packages/foundations/src/themes/inline-error.ts
+++ b/packages/foundations/src/themes/inline-error.ts
@@ -10,11 +10,11 @@ export const inlineErrorDefault: { inlineError: InlineErrorTheme } = {
 	},
 }
 
-export const inlineErrorBrandDefault: { inlineError: InlineErrorTheme } = {
+export const inlineErrorBrand: { inlineError: InlineErrorTheme } = {
 	inlineError: {
 		text: palette.text.brand.error,
 	},
 }
 
+// continue to expose legacy theme names
 export const inlineErrorLight = inlineErrorDefault
-export const inlineErrorBrand = inlineErrorBrandDefault

--- a/packages/foundations/src/themes/inline-error.ts
+++ b/packages/foundations/src/themes/inline-error.ts
@@ -4,14 +4,17 @@ export type InlineErrorTheme = {
 	text: string
 }
 
-export const inlineErrorLight: { inlineError: InlineErrorTheme } = {
+export const inlineErrorDefault: { inlineError: InlineErrorTheme } = {
 	inlineError: {
 		text: palette.text.error,
 	},
 }
 
-export const inlineErrorBrand: { inlineError: InlineErrorTheme } = {
+export const inlineErrorBrandDefault: { inlineError: InlineErrorTheme } = {
 	inlineError: {
 		text: palette.text.brand.error,
 	},
 }
+
+export const inlineErrorLight = inlineErrorDefault
+export const inlineErrorBrand = inlineErrorBrandDefault

--- a/packages/foundations/src/themes/link.ts
+++ b/packages/foundations/src/themes/link.ts
@@ -16,10 +16,10 @@ export const linkDefault: { link: LinkTheme } = {
 	},
 }
 
-export const linkBrandDefault: { link: LinkTheme } = {
+export const linkBrand: { link: LinkTheme } = {
 	link: {
-		textPrimary: palette.text.brandDefault.linkPrimary,
-		textPrimaryHover: palette.text.brandDefault.linkPrimaryHover,
+		textPrimary: palette.text.brand.linkPrimary,
+		textPrimaryHover: palette.text.brand.linkPrimaryHover,
 	},
 }
 
@@ -32,15 +32,13 @@ export const linkBrandAlt: { link: LinkTheme } = {
 
 // continue to expose legacy theme names
 export const linkLight = linkDefault
-export const linkBrand = linkBrandDefault
 export const linkBrandYellow = linkBrandAlt
 
 export const link = {
 	linkDefault,
-	linkBrandDefault,
+	linkBrand,
 	linkBrandAlt,
 	// continue to expose legacy theme names
 	linkLight,
-	linkBrand,
 	linkBrandYellow,
 }

--- a/packages/foundations/src/themes/link.ts
+++ b/packages/foundations/src/themes/link.ts
@@ -33,12 +33,3 @@ export const linkBrandAlt: { link: LinkTheme } = {
 // continue to expose legacy theme names
 export const linkLight = linkDefault
 export const linkBrandYellow = linkBrandAlt
-
-export const link = {
-	linkDefault,
-	linkBrand,
-	linkBrandAlt,
-	// continue to expose legacy theme names
-	linkLight,
-	linkBrandYellow,
-}

--- a/packages/foundations/src/themes/link.ts
+++ b/packages/foundations/src/themes/link.ts
@@ -7,7 +7,7 @@ export type LinkTheme = {
 	textSecondaryHover?: string
 }
 
-export const linkLight: { link: LinkTheme } = {
+export const linkDefault: { link: LinkTheme } = {
 	link: {
 		textPrimary: palette.text.linkPrimary,
 		textPrimaryHover: palette.text.linkPrimaryHover,
@@ -16,21 +16,30 @@ export const linkLight: { link: LinkTheme } = {
 	},
 }
 
-export const linkBrand: { link: LinkTheme } = {
+export const linkBrandDefault: { link: LinkTheme } = {
 	link: {
-		textPrimary: palette.text.brand.linkPrimary,
-		textPrimaryHover: palette.text.brand.linkPrimaryHover,
+		textPrimary: palette.text.brandDefault.linkPrimary,
+		textPrimaryHover: palette.text.brandDefault.linkPrimaryHover,
 	},
 }
 
-export const linkBrandYellow: { link: LinkTheme } = {
+export const linkBrandAlt: { link: LinkTheme } = {
 	link: {
-		textPrimary: palette.text.brandYellow.linkPrimary,
-		textPrimaryHover: palette.text.brandYellow.linkPrimaryHover,
+		textPrimary: palette.text.brandAlt.linkPrimary,
+		textPrimaryHover: palette.text.brandAlt.linkPrimaryHover,
 	},
 }
+
+// continue to expose legacy theme names
+export const linkLight = linkDefault
+export const linkBrand = linkBrandDefault
+export const linkBrandYellow = linkBrandAlt
 
 export const link = {
+	linkDefault,
+	linkBrandDefault,
+	linkBrandAlt,
+	// continue to expose legacy theme names
 	linkLight,
 	linkBrand,
 	linkBrandYellow,

--- a/packages/foundations/src/themes/radio.ts
+++ b/packages/foundations/src/themes/radio.ts
@@ -29,7 +29,7 @@ export const radioDefault: {
 	...inlineErrorLight,
 }
 
-export const radioBrandDefault: {
+export const radioBrand: {
 	radio: RadioTheme
 	inlineError: InlineErrorTheme
 } = {
@@ -46,4 +46,3 @@ export const radioBrandDefault: {
 
 // continue to expose legacy theme names
 export const radioLight = radioDefault
-export const radioBrand = radioBrandDefault

--- a/packages/foundations/src/themes/radio.ts
+++ b/packages/foundations/src/themes/radio.ts
@@ -14,7 +14,7 @@ export type RadioTheme = {
 	borderError: string
 }
 
-export const radioLight: {
+export const radioDefault: {
 	radio: RadioTheme
 	inlineError: InlineErrorTheme
 } = {
@@ -29,7 +29,7 @@ export const radioLight: {
 	...inlineErrorLight,
 }
 
-export const radioBrand: {
+export const radioBrandDefault: {
 	radio: RadioTheme
 	inlineError: InlineErrorTheme
 } = {
@@ -43,3 +43,7 @@ export const radioBrand: {
 	},
 	...inlineErrorBrand,
 }
+
+// continue to expose legacy theme names
+export const radioLight = radioDefault
+export const radioBrand = radioBrandDefault

--- a/packages/foundations/src/themes/text-input.ts
+++ b/packages/foundations/src/themes/text-input.ts
@@ -1,5 +1,5 @@
 import { palette } from "../index"
-import { inlineErrorLight, InlineErrorTheme } from "./inline-error"
+import { inlineErrorDefault, InlineErrorTheme } from "./inline-error"
 
 export type TextInputTheme = {
 	textInput: string
@@ -12,7 +12,7 @@ export type TextInputTheme = {
 	borderError: string
 }
 
-export const textInputLight: {
+export const textInputDefault: {
 	textInput: TextInputTheme
 	inlineError: InlineErrorTheme
 } = {
@@ -26,5 +26,8 @@ export const textInputLight: {
 		border: palette.border.textInput,
 		borderError: palette.border.textInputError,
 	},
-	...inlineErrorLight,
+	...inlineErrorDefault,
 }
+
+// continue to expose legacy theme names
+export const textInputLight = textInputDefault


### PR DESCRIPTION
## What is the purpose of this change?

It was decided the current theme names tend to be:

- tightly coupled to hue names and relative lightness
- confusing (e.g. does the `Yellow` in `brandYellow` refer to the background colour of the component or the background colour of the theme, or something else?)

## What does this change?

Rename the themes to be more generic-sounding:

- light -> default
- brand -> brand
- brandYellow -> brandAlt
- readerRevenue -> readerRevenue
- readerRevenueYellow -> readerRevenueAlt

For now, continue to expose the legacy theme names for the sake of backward compatibility 
