### PR TITLE
Expose new theme names in helpers

### DIFF
--- a/packages/helpers/storybook-bg.ts
+++ b/packages/helpers/storybook-bg.ts
@@ -7,8 +7,14 @@ const storybookBackgrounds: {
 		value: string
 	}
 } = {
-	light: { name: "light", value: palette.background.primary },
+	default: { name: "default", value: palette.background.primary },
 	brand: { name: "brand", value: palette.background.brand.primary },
+	brandAlt: {
+		name: "brandAlt",
+		value: palette.background.brandAlt.primary,
+	},
+	// continue to expose legacy theme names
+	light: { name: "light", value: palette.background.primary },
 	brandYellow: {
 		name: "brandYellow",
 		value: palette.background.brandYellow.primary,

--- a/packages/helpers/types.ts
+++ b/packages/helpers/types.ts
@@ -1,1 +1,6 @@
-export type ThemeName = "light" | "brand" | "brandYellow"
+export type ThemeName =
+	| "default"
+	| "light"
+	| "brand"
+	| "brandYellow"
+	| "brandAlt"


### PR DESCRIPTION
## What is the purpose of this change?

Continuation of #190 

## What does this change?

Exposes new theme names:

- default (aka light)
- brandAlt (aka brandYellow)
