### PR TITLE
Treeshakeable palette

### DIFF
--- a/packages/foundations/rollup.config.js
+++ b/packages/foundations/rollup.config.js
@@ -3,6 +3,9 @@ import resolve from "rollup-plugin-node-resolve"
 
 const extensions = [".ts", ".tsx"]
 const plugins = [babel({ extensions }), resolve({ extensions })]
+
+// NOTE: the palette folder (not included here) is built as a side effect of the
+// palette being exposed by src/index.ts
 const folders = ["accessibility", "mq", "themes", "typography"].map(folder => ({
 	input: `src/${folder}/index.ts`,
 	output: [

--- a/packages/foundations/src/index.ts
+++ b/packages/foundations/src/index.ts
@@ -3,3 +3,39 @@ export * from "./breakpoints"
 export * from "./palette"
 export * from "./size"
 export * from "./space"
+
+import {
+	brand,
+	brandYellow,
+	neutral,
+	error,
+	success,
+	news,
+	opinion,
+	sport,
+	culture,
+	lifestyle,
+	labs,
+	background,
+	border,
+	line,
+	text,
+} from "./palette"
+
+export const palette = {
+	background,
+	border,
+	line,
+	text,
+	brand,
+	brandYellow,
+	neutral,
+	error,
+	success,
+	news,
+	opinion,
+	sport,
+	culture,
+	lifestyle,
+	labs,
+}

--- a/packages/foundations/src/palette/index.ts
+++ b/packages/foundations/src/palette/index.ts
@@ -1,4 +1,4 @@
-import {
+export {
 	brand,
 	brandYellow,
 	neutral,
@@ -11,25 +11,7 @@ import {
 	lifestyle,
 	labs,
 } from "./global"
-import { background } from "./background"
-import { border } from "./border"
-import { line } from "./line"
-import { text } from "./text"
-
-export const palette = {
-	background,
-	border,
-	line,
-	text,
-	brand,
-	brandYellow,
-	neutral,
-	error,
-	success,
-	news,
-	opinion,
-	sport,
-	culture,
-	lifestyle,
-	labs,
-}
+export { background } from "./background"
+export { border } from "./border"
+export { line } from "./line"
+export { text } from "./text"

--- a/packages/foundations/src/themes/button.ts
+++ b/packages/foundations/src/themes/button.ts
@@ -1,4 +1,4 @@
-import { palette } from "../index"
+import { text, background } from "../index"
 
 export type ButtonTheme = {
 	textPrimary: string
@@ -14,41 +14,40 @@ export type ButtonTheme = {
 
 export const buttonDefault: { button: ButtonTheme } = {
 	button: {
-		textPrimary: palette.text.buttonPrimary,
-		backgroundPrimary: palette.background.buttonPrimary,
-		backgroundPrimaryHover: palette.background.buttonPrimaryHover,
-		textSecondary: palette.text.buttonSecondary,
-		backgroundSecondary: palette.background.buttonSecondary,
-		backgroundSecondaryHover: palette.background.buttonSecondaryHover,
-		textTertiary: palette.text.buttonSecondary,
-		backgroundTertiary: palette.background.primary,
+		textPrimary: text.buttonPrimary,
+		backgroundPrimary: background.buttonPrimary,
+		backgroundPrimaryHover: background.buttonPrimaryHover,
+		textSecondary: text.buttonSecondary,
+		backgroundSecondary: background.buttonSecondary,
+		backgroundSecondaryHover: background.buttonSecondaryHover,
+		textTertiary: text.buttonSecondary,
+		backgroundTertiary: background.primary,
 	},
 }
 
 export const buttonBrand: { button: ButtonTheme } = {
 	button: {
-		textPrimary: palette.text.brand.buttonPrimary,
-		backgroundPrimary: palette.background.brand.buttonPrimary,
-		backgroundPrimaryHover: palette.background.brand.buttonPrimaryHover,
-		textSecondary: palette.text.brand.buttonSecondary,
-		backgroundSecondary: palette.background.brand.buttonSecondary,
-		backgroundSecondaryHover: palette.background.brand.buttonSecondaryHover,
-		textTertiary: palette.text.brand.buttonSecondary,
-		backgroundTertiary: palette.background.brand.primary,
+		textPrimary: text.brand.buttonPrimary,
+		backgroundPrimary: background.brand.buttonPrimary,
+		backgroundPrimaryHover: background.brand.buttonPrimaryHover,
+		textSecondary: text.brand.buttonSecondary,
+		backgroundSecondary: background.brand.buttonSecondary,
+		backgroundSecondaryHover: background.brand.buttonSecondaryHover,
+		textTertiary: text.brand.buttonSecondary,
+		backgroundTertiary: background.brand.primary,
 	},
 }
 
 export const buttonBrandAlt: { button: ButtonTheme } = {
 	button: {
-		textPrimary: palette.text.brandAlt.buttonPrimary,
-		backgroundPrimary: palette.background.brandAlt.buttonPrimary,
-		backgroundPrimaryHover: palette.background.brandAlt.buttonPrimaryHover,
-		textSecondary: palette.text.brandAlt.buttonSecondary,
-		backgroundSecondary: palette.background.brandAlt.buttonSecondary,
-		backgroundSecondaryHover:
-			palette.background.brandAlt.buttonSecondaryHover,
-		textTertiary: palette.text.brandAlt.buttonSecondary,
-		backgroundTertiary: palette.background.brandAlt.primary,
+		textPrimary: text.brandAlt.buttonPrimary,
+		backgroundPrimary: background.brandAlt.buttonPrimary,
+		backgroundPrimaryHover: background.brandAlt.buttonPrimaryHover,
+		textSecondary: text.brandAlt.buttonSecondary,
+		backgroundSecondary: background.brandAlt.buttonSecondary,
+		backgroundSecondaryHover: background.brandAlt.buttonSecondaryHover,
+		textTertiary: text.brandAlt.buttonSecondary,
+		backgroundTertiary: background.brandAlt.primary,
 	},
 }
 

--- a/packages/foundations/src/themes/checkbox.ts
+++ b/packages/foundations/src/themes/checkbox.ts
@@ -1,4 +1,4 @@
-import { palette } from "../index"
+import { border, background, text } from "../index"
 import {
 	inlineErrorDefault,
 	inlineErrorBrand,
@@ -21,14 +21,14 @@ export const checkboxDefault: {
 	inlineError: InlineErrorTheme
 } = {
 	checkbox: {
-		border: palette.border.checkbox,
-		borderHover: palette.border.checkboxHover,
-		borderChecked: palette.border.checkboxChecked,
-		borderError: palette.border.checkboxError,
-		backgroundChecked: palette.background.checkboxChecked,
-		text: palette.text.checkbox,
-		textSupporting: palette.text.checkboxSupporting,
-		textIndeterminate: palette.text.checkboxIndeterminate,
+		border: border.checkbox,
+		borderHover: border.checkboxHover,
+		borderChecked: border.checkboxChecked,
+		borderError: border.checkboxError,
+		backgroundChecked: background.checkboxChecked,
+		text: text.checkbox,
+		textSupporting: text.checkboxSupporting,
+		textIndeterminate: text.checkboxIndeterminate,
 	},
 	...inlineErrorDefault,
 }
@@ -38,14 +38,14 @@ export const checkboxBrand: {
 	inlineError: InlineErrorTheme
 } = {
 	checkbox: {
-		border: palette.border.brand.checkbox,
-		borderHover: palette.border.brand.checkboxHover,
-		borderChecked: palette.border.brand.checkboxChecked,
-		borderError: palette.border.brand.checkboxError,
-		backgroundChecked: palette.background.brand.checkboxChecked,
-		text: palette.text.brand.checkbox,
-		textSupporting: palette.text.brand.checkboxSupporting,
-		textIndeterminate: palette.text.brand.checkboxIndeterminate,
+		border: border.brand.checkbox,
+		borderHover: border.brand.checkboxHover,
+		borderChecked: border.brand.checkboxChecked,
+		borderError: border.brand.checkboxError,
+		backgroundChecked: background.brand.checkboxChecked,
+		text: text.brand.checkbox,
+		textSupporting: text.brand.checkboxSupporting,
+		textIndeterminate: text.brand.checkboxIndeterminate,
 	},
 	...inlineErrorBrand,
 }

--- a/packages/foundations/src/themes/inline-error.ts
+++ b/packages/foundations/src/themes/inline-error.ts
@@ -1,4 +1,4 @@
-import { palette } from "../index"
+import { text } from "../index"
 
 export type InlineErrorTheme = {
 	text: string
@@ -6,13 +6,13 @@ export type InlineErrorTheme = {
 
 export const inlineErrorDefault: { inlineError: InlineErrorTheme } = {
 	inlineError: {
-		text: palette.text.error,
+		text: text.error,
 	},
 }
 
 export const inlineErrorBrand: { inlineError: InlineErrorTheme } = {
 	inlineError: {
-		text: palette.text.brand.error,
+		text: text.brand.error,
 	},
 }
 

--- a/packages/foundations/src/themes/link.ts
+++ b/packages/foundations/src/themes/link.ts
@@ -1,4 +1,4 @@
-import { palette } from "../index"
+import { text } from "../index"
 
 export type LinkTheme = {
 	textPrimary: string
@@ -9,24 +9,24 @@ export type LinkTheme = {
 
 export const linkDefault: { link: LinkTheme } = {
 	link: {
-		textPrimary: palette.text.linkPrimary,
-		textPrimaryHover: palette.text.linkPrimaryHover,
-		textSecondary: palette.text.linkSecondary,
-		textSecondaryHover: palette.text.linkSecondaryHover,
+		textPrimary: text.linkPrimary,
+		textPrimaryHover: text.linkPrimaryHover,
+		textSecondary: text.linkSecondary,
+		textSecondaryHover: text.linkSecondaryHover,
 	},
 }
 
 export const linkBrand: { link: LinkTheme } = {
 	link: {
-		textPrimary: palette.text.brand.linkPrimary,
-		textPrimaryHover: palette.text.brand.linkPrimaryHover,
+		textPrimary: text.brand.linkPrimary,
+		textPrimaryHover: text.brand.linkPrimaryHover,
 	},
 }
 
 export const linkBrandAlt: { link: LinkTheme } = {
 	link: {
-		textPrimary: palette.text.brandAlt.linkPrimary,
-		textPrimaryHover: palette.text.brandAlt.linkPrimaryHover,
+		textPrimary: text.brandAlt.linkPrimary,
+		textPrimaryHover: text.brandAlt.linkPrimaryHover,
 	},
 }
 

--- a/packages/foundations/src/themes/radio.ts
+++ b/packages/foundations/src/themes/radio.ts
@@ -1,4 +1,4 @@
-import { palette } from "../index"
+import { border, background, text } from "../index"
 import {
 	inlineErrorLight,
 	inlineErrorBrand,
@@ -19,12 +19,12 @@ export const radioDefault: {
 	inlineError: InlineErrorTheme
 } = {
 	radio: {
-		borderHover: palette.border.radioHover,
-		border: palette.border.radio,
-		backgroundChecked: palette.background.radioChecked,
-		text: palette.text.radio,
-		textSupporting: palette.text.radioSupporting,
-		borderError: palette.border.radioError,
+		borderHover: border.radioHover,
+		border: border.radio,
+		backgroundChecked: background.radioChecked,
+		text: text.radio,
+		textSupporting: text.radioSupporting,
+		borderError: border.radioError,
 	},
 	...inlineErrorLight,
 }
@@ -34,12 +34,12 @@ export const radioBrand: {
 	inlineError: InlineErrorTheme
 } = {
 	radio: {
-		borderHover: palette.border.brand.radioHover,
-		border: palette.border.brand.radio,
-		backgroundChecked: palette.background.brand.radioChecked,
-		text: palette.text.brand.radio,
-		textSupporting: palette.text.brand.radioSupporting,
-		borderError: palette.border.brand.radioError,
+		borderHover: border.brand.radioHover,
+		border: border.brand.radio,
+		backgroundChecked: background.brand.radioChecked,
+		text: text.brand.radio,
+		textSupporting: text.brand.radioSupporting,
+		borderError: border.brand.radioError,
 	},
 	...inlineErrorBrand,
 }

--- a/packages/foundations/src/themes/text-input.ts
+++ b/packages/foundations/src/themes/text-input.ts
@@ -1,4 +1,4 @@
-import { palette } from "../index"
+import { text, background, border } from "../index"
 import { inlineErrorDefault, InlineErrorTheme } from "./inline-error"
 
 export type TextInputTheme = {
@@ -17,14 +17,14 @@ export const textInputDefault: {
 	inlineError: InlineErrorTheme
 } = {
 	textInput: {
-		textInput: palette.text.textInput,
-		textLabel: palette.text.textInputLabel,
-		textOptionalLabel: palette.text.textInputOptionalLabel,
-		textSupporting: palette.text.textInputSupporting,
-		textError: palette.text.textInputError,
-		backgroundInput: palette.background.textInput,
-		border: palette.border.textInput,
-		borderError: palette.border.textInputError,
+		textInput: text.textInput,
+		textLabel: text.textInputLabel,
+		textOptionalLabel: text.textInputOptionalLabel,
+		textSupporting: text.textInputSupporting,
+		textError: text.textInputError,
+		backgroundInput: background.textInput,
+		border: border.textInput,
+		borderError: border.textInputError,
 	},
 	...inlineErrorDefault,
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
 			"@guardian/src-foundations/accessibility": [
 				"foundations/src/accessibility"
 			],
+			"@guardian/src-foundations/palette": ["foundations/src/palette"],
 			"@guardian/src-foundations/themes": ["foundations/src/themes"],
 			"@guardian/src-foundations/typography": [
 				"foundations/src/typography"


### PR DESCRIPTION
## What is the purpose of this change?

Currently consumers of foundations must load in the entire palette in order to use any colours. This is inefficient as it means all colours get shipped to the user even if only a subset are used.

We should expose the functional and global colours as discretely importable modules, making the palette tree-shakeable and ultimately more efficient.

We should continue to allow consumers to import the entire palette, for developer convenience, should they wish to do so.

## What does this change?

Exposes the new `palette` folder as part of the foundations API:

```ts
import { css } from '@emotion/core'
import { text } from '@guardian/src-foundations/palette'

const bodyText = css`
  color: ${text.primary};
`

// ...
```

This change also updates the themes to use the new palette API
