### PR TITLE
Import individual global colours in button themes

### DIFF
--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -89,11 +89,11 @@ The side of the button on which the icon appears
 
 ### Standard
 
--   `light`
+-   `default`
 -   `brand`
--   `brandYellow`
+-   `brandAlt`
 
 ### Custom
 
 -   `readerRevenue`
--   `readerRevenueYellow`
+-   `readerRevenueAlt`

--- a/packages/button/rollup.config.js
+++ b/packages/button/rollup.config.js
@@ -22,6 +22,7 @@ module.exports = {
 		"@emotion/css",
 		"@guardian/src-foundations",
 		"@guardian/src-foundations/accessibility",
+		"@guardian/src-foundations/palette",
 		"@guardian/src-foundations/themes",
 		"@guardian/src-foundations/typography",
 	],

--- a/packages/button/themes.ts
+++ b/packages/button/themes.ts
@@ -1,42 +1,42 @@
-import { palette } from "@guardian/src-foundations"
+import { neutral, brand, brandYellow } from "@guardian/src-foundations/palette"
 import { ButtonTheme } from "@guardian/src-foundations/themes"
 
 const text = {
 	readerRevenue: {
-		primary: palette.neutral[100],
-		secondary: palette.neutral[60],
-		ctaPrimary: palette.brand[400],
-		ctaSecondary: palette.brandYellow[400],
+		primary: neutral[100],
+		secondary: neutral[60],
+		ctaPrimary: brand[400],
+		ctaSecondary: brandYellow[400],
 	},
 	readerRevenueAlt: {
-		primary: palette.neutral[7],
-		secondary: palette.neutral[60],
-		ctaPrimary: palette.neutral[100],
-		ctaSecondary: palette.neutral[7],
+		primary: neutral[7],
+		secondary: neutral[60],
+		ctaPrimary: neutral[100],
+		ctaSecondary: neutral[7],
 	},
 }
 const background = {
 	readerRevenue: {
-		primary: palette.brand[400],
-		ctaPrimary: palette.brandYellow[400],
-		ctaPrimaryHover: palette.brandYellow[300],
-		ctaSecondary: palette.brand[400],
+		primary: brand[400],
+		ctaPrimary: brandYellow[400],
+		ctaPrimaryHover: brandYellow[300],
+		ctaSecondary: brand[400],
 		ctaSecondaryHover: "#234B8A",
 	},
 	readerRevenueAlt: {
-		primary: palette.brandYellow[400],
-		ctaPrimary: palette.neutral[7],
+		primary: brandYellow[400],
+		ctaPrimary: neutral[7],
 		ctaPrimaryHover: "#454545",
-		ctaSecondary: palette.brandYellow[400],
-		ctaSecondaryHover: palette.brandYellow[300],
+		ctaSecondary: brandYellow[400],
+		ctaSecondaryHover: brandYellow[300],
 	},
 }
 const border = {
 	readerRevenue: {
-		ctaSecondary: palette.brandYellow[400],
+		ctaSecondary: brandYellow[400],
 	},
 	readerRevenueAlt: {
-		ctaSecondary: palette.neutral[7],
+		ctaSecondary: neutral[7],
 	},
 }
 


### PR DESCRIPTION
## What is the purpose of this change?

The button themes are currently drawing colours direct from the `palette` object. We should switch to importing individual global colous as this is more efficient

## What does this change?

Imports colours from `@guardian/src-foundations/palette` instead of the top level `palette` object
