### PR TITLE
Expose functional colours by theme

### DIFF
--- a/packages/foundations/README.md
+++ b/packages/foundations/README.md
@@ -13,10 +13,10 @@ $ yarn add @guardian/src-foundations
 ### [Palette](https://zeroheight.com/2a1e5182b/p/938810)
 
 ```ts
-import { palette } from "@guardian/src-foundations"
+import { background } from "@guardian/src-foundations/palette"
 
 const backgroundColor = css`
-    background-color: ${palette.neutral[97]};
+    background-color: ${background.primary};
 `
 ```
 

--- a/packages/foundations/src/index.ts
+++ b/packages/foundations/src/index.ts
@@ -6,14 +6,15 @@ export * from "./space"
 
 import {
 	background,
-	brandBackground,
-	brandAltBackground,
 	border,
 	line,
-	brandLine,
-	brandAltLine,
 	text,
+	brandBackground,
+	brandBorder,
+	brandLine,
 	brandText,
+	brandAltBackground,
+	brandAltLine,
 	brandAltText,
 	brand,
 	brandYellow,
@@ -36,6 +37,7 @@ export const palette = {
 	text,
 	// functional colours (brand)
 	brandBackground,
+	brandBorder,
 	brandLine,
 	brandText,
 	// functional colours (brandAlt)

--- a/packages/foundations/src/index.ts
+++ b/packages/foundations/src/index.ts
@@ -5,6 +5,12 @@ export * from "./size"
 export * from "./space"
 
 import {
+	background,
+	border,
+	line,
+	brandLine,
+	brandAltLine,
+	text,
 	brand,
 	brandYellow,
 	neutral,
@@ -16,17 +22,18 @@ import {
 	culture,
 	lifestyle,
 	labs,
-	background,
-	border,
-	line,
-	text,
 } from "./palette"
 
 export const palette = {
+	// functional colours
 	background,
 	border,
 	line,
+	brandLine,
+	brandAltLine,
 	text,
+
+	// global colours
 	brand,
 	brandYellow,
 	neutral,

--- a/packages/foundations/src/index.ts
+++ b/packages/foundations/src/index.ts
@@ -6,6 +6,8 @@ export * from "./space"
 
 import {
 	background,
+	brandBackground,
+	brandAltBackground,
 	border,
 	line,
 	brandLine,
@@ -33,12 +35,13 @@ export const palette = {
 	line,
 	text,
 	// functional colours (brand)
+	brandBackground,
 	brandLine,
 	brandText,
 	// functional colours (brandAlt)
+	brandAltBackground,
 	brandAltLine,
 	brandAltText,
-
 	// global colours
 	brand,
 	brandYellow,

--- a/packages/foundations/src/index.ts
+++ b/packages/foundations/src/index.ts
@@ -11,6 +11,8 @@ import {
 	brandLine,
 	brandAltLine,
 	text,
+	brandText,
+	brandAltText,
 	brand,
 	brandYellow,
 	neutral,
@@ -25,13 +27,17 @@ import {
 } from "./palette"
 
 export const palette = {
-	// functional colours
+	// functional colours (default)
 	background,
 	border,
 	line,
-	brandLine,
-	brandAltLine,
 	text,
+	// functional colours (brand)
+	brandLine,
+	brandText,
+	// functional colours (brandAlt)
+	brandAltLine,
+	brandAltText,
 
 	// global colours
 	brand,

--- a/packages/foundations/src/palette/background.ts
+++ b/packages/foundations/src/palette/background.ts
@@ -1,13 +1,5 @@
 import { neutral, brand, brandYellow } from "./global"
 
-const brandAlt = {
-	primary: brandYellow[400],
-	buttonPrimary: neutral[7],
-	buttonPrimaryHover: "#454545",
-	buttonSecondary: brandYellow[300],
-	buttonSecondaryHover: "#F2AE00",
-}
-
 export const background = {
 	primary: neutral[100],
 	buttonPrimary: brand[400],
@@ -17,16 +9,22 @@ export const background = {
 	checkboxChecked: brand[500],
 	radioChecked: brand[500],
 	textInput: neutral[100],
-	brand: {
-		primary: brand[400],
-		buttonPrimary: neutral[100],
-		buttonPrimaryHover: "#E0E0E0",
-		buttonSecondary: brand[600],
-		buttonSecondaryHover: "#234B8A",
-		checkboxChecked: neutral[100],
-		radioChecked: neutral[100],
-	},
-	brandAlt,
-	// continue to expose legacy theme names
-	brandYellow: brandAlt,
+}
+
+export const brandBackground = {
+	primary: brand[400],
+	buttonPrimary: neutral[100],
+	buttonPrimaryHover: "#E0E0E0",
+	buttonSecondary: brand[600],
+	buttonSecondaryHover: "#234B8A",
+	checkboxChecked: neutral[100],
+	radioChecked: neutral[100],
+}
+
+export const brandAltBackground = {
+	primary: brandYellow[400],
+	buttonPrimary: neutral[7],
+	buttonPrimaryHover: "#454545",
+	buttonSecondary: brandYellow[300],
+	buttonSecondaryHover: "#F2AE00",
 }

--- a/packages/foundations/src/palette/border.ts
+++ b/packages/foundations/src/palette/border.ts
@@ -14,14 +14,14 @@ export const border = {
 	radioError: error[400],
 	textInput: neutral[60],
 	textInputError: error[400],
-	brand: {
-		error: error[500],
-		checkbox: brand[800],
-		checkboxHover: neutral[100],
-		checkboxChecked: neutral[100],
-		checkboxError: error[500],
-		radio: brand[800],
-		radioHover: neutral[100],
-		radioError: error[500],
-	},
+}
+export const brandBorder = {
+	error: error[500],
+	checkbox: brand[800],
+	checkboxHover: neutral[100],
+	checkboxChecked: neutral[100],
+	checkboxError: error[500],
+	radio: brand[800],
+	radioHover: neutral[100],
+	radioError: error[500],
 }

--- a/packages/foundations/src/palette/index.ts
+++ b/packages/foundations/src/palette/index.ts
@@ -13,5 +13,5 @@ export {
 } from "./global"
 export { background } from "./background"
 export { border } from "./border"
-export { line } from "./line"
+export { line, brandLine, brandAltLine } from "./line"
 export { text } from "./text"

--- a/packages/foundations/src/palette/index.ts
+++ b/packages/foundations/src/palette/index.ts
@@ -14,4 +14,4 @@ export {
 export { background } from "./background"
 export { border } from "./border"
 export { line, brandLine, brandAltLine } from "./line"
-export { text } from "./text"
+export { text, brandText, brandAltText } from "./text"

--- a/packages/foundations/src/palette/index.ts
+++ b/packages/foundations/src/palette/index.ts
@@ -12,6 +12,6 @@ export {
 	labs,
 } from "./global"
 export { background, brandBackground, brandAltBackground } from "./background"
-export { border } from "./border"
+export { border, brandBorder } from "./border"
 export { line, brandLine, brandAltLine } from "./line"
 export { text, brandText, brandAltText } from "./text"

--- a/packages/foundations/src/palette/index.ts
+++ b/packages/foundations/src/palette/index.ts
@@ -11,7 +11,7 @@ export {
 	lifestyle,
 	labs,
 } from "./global"
-export { background } from "./background"
+export { background, brandBackground, brandAltBackground } from "./background"
 export { border } from "./border"
 export { line, brandLine, brandAltLine } from "./line"
 export { text, brandText, brandAltText } from "./text"

--- a/packages/foundations/src/palette/line.ts
+++ b/packages/foundations/src/palette/line.ts
@@ -1,14 +1,13 @@
 import { neutral, brand } from "./global"
 
-const brandAlt = {
-	primary: neutral[7],
-}
 export const line = {
 	primary: neutral[86],
-	brand: {
-		primary: brand[600],
-	},
-	brandAlt,
-	// continue to expose legacy theme names
-	brandYellow: brandAlt,
+}
+
+export const brandLine = {
+	primary: brand[600],
+}
+
+export const brandAltLine = {
+	primary: neutral[7],
 }

--- a/packages/foundations/src/palette/text.ts
+++ b/packages/foundations/src/palette/text.ts
@@ -1,13 +1,5 @@
 import { neutral, error, brand } from "./global"
 
-const brandAlt = {
-	primary: neutral[7],
-	secondary: neutral[60],
-	buttonPrimary: neutral[100],
-	buttonSecondary: neutral[7],
-	linkPrimary: neutral[7],
-	linkPrimaryHover: neutral[7],
-}
 export const text = {
 	primary: neutral[7],
 	secondary: neutral[46],
@@ -28,21 +20,28 @@ export const text = {
 	textInputOptionalLabel: neutral[46],
 	textInputSupporting: neutral[46],
 	textInputError: error[400],
-	brand: {
-		primary: neutral[100],
-		secondary: brand[800],
-		error: error[500],
-		buttonPrimary: brand[400],
-		buttonSecondary: neutral[100],
-		checkbox: neutral[100],
-		checkboxSupporting: brand[800],
-		checkboxIndeterminate: brand[800],
-		linkPrimary: neutral[100],
-		linkPrimaryHover: neutral[100],
-		radio: neutral[100],
-		radioSupporting: brand[800],
-	},
-	brandAlt,
-	// continue to expose legacy theme names
-	brandYellow: brandAlt,
+}
+
+export const brandText = {
+	primary: neutral[100],
+	secondary: brand[800],
+	error: error[500],
+	buttonPrimary: brand[400],
+	buttonSecondary: neutral[100],
+	checkbox: neutral[100],
+	checkboxSupporting: brand[800],
+	checkboxIndeterminate: brand[800],
+	linkPrimary: neutral[100],
+	linkPrimaryHover: neutral[100],
+	radio: neutral[100],
+	radioSupporting: brand[800],
+}
+
+export const brandAltText = {
+	primary: neutral[7],
+	secondary: neutral[60],
+	buttonPrimary: neutral[100],
+	buttonSecondary: neutral[7],
+	linkPrimary: neutral[7],
+	linkPrimaryHover: neutral[7],
 }

--- a/packages/foundations/src/themes/button.ts
+++ b/packages/foundations/src/themes/button.ts
@@ -1,4 +1,11 @@
-import { text, background } from "../index"
+import {
+	text,
+	background,
+	brandText,
+	brandBackground,
+	brandAltText,
+	brandAltBackground,
+} from "../index"
 
 export type ButtonTheme = {
 	textPrimary: string
@@ -27,27 +34,27 @@ export const buttonDefault: { button: ButtonTheme } = {
 
 export const buttonBrand: { button: ButtonTheme } = {
 	button: {
-		textPrimary: text.brand.buttonPrimary,
-		backgroundPrimary: background.brand.buttonPrimary,
-		backgroundPrimaryHover: background.brand.buttonPrimaryHover,
-		textSecondary: text.brand.buttonSecondary,
-		backgroundSecondary: background.brand.buttonSecondary,
-		backgroundSecondaryHover: background.brand.buttonSecondaryHover,
-		textTertiary: text.brand.buttonSecondary,
-		backgroundTertiary: background.brand.primary,
+		textPrimary: brandText.buttonPrimary,
+		backgroundPrimary: brandBackground.buttonPrimary,
+		backgroundPrimaryHover: brandBackground.buttonPrimaryHover,
+		textSecondary: brandText.buttonSecondary,
+		backgroundSecondary: brandBackground.buttonSecondary,
+		backgroundSecondaryHover: brandBackground.buttonSecondaryHover,
+		textTertiary: brandText.buttonSecondary,
+		backgroundTertiary: brandBackground.primary,
 	},
 }
 
 export const buttonBrandAlt: { button: ButtonTheme } = {
 	button: {
-		textPrimary: text.brandAlt.buttonPrimary,
-		backgroundPrimary: background.brandAlt.buttonPrimary,
-		backgroundPrimaryHover: background.brandAlt.buttonPrimaryHover,
-		textSecondary: text.brandAlt.buttonSecondary,
-		backgroundSecondary: background.brandAlt.buttonSecondary,
-		backgroundSecondaryHover: background.brandAlt.buttonSecondaryHover,
-		textTertiary: text.brandAlt.buttonSecondary,
-		backgroundTertiary: background.brandAlt.primary,
+		textPrimary: brandAltText.buttonPrimary,
+		backgroundPrimary: brandAltBackground.buttonPrimary,
+		backgroundPrimaryHover: brandAltBackground.buttonPrimaryHover,
+		textSecondary: brandAltText.buttonSecondary,
+		backgroundSecondary: brandAltBackground.buttonSecondary,
+		backgroundSecondaryHover: brandAltBackground.buttonSecondaryHover,
+		textTertiary: brandAltText.buttonSecondary,
+		backgroundTertiary: brandAltBackground.primary,
 	},
 }
 

--- a/packages/foundations/src/themes/checkbox.ts
+++ b/packages/foundations/src/themes/checkbox.ts
@@ -1,4 +1,11 @@
-import { border, background, text } from "../index"
+import {
+	border,
+	background,
+	text,
+	brandBorder,
+	brandBackground,
+	brandText,
+} from "../index"
 import {
 	inlineErrorDefault,
 	inlineErrorBrand,
@@ -38,14 +45,14 @@ export const checkboxBrand: {
 	inlineError: InlineErrorTheme
 } = {
 	checkbox: {
-		border: border.brand.checkbox,
-		borderHover: border.brand.checkboxHover,
-		borderChecked: border.brand.checkboxChecked,
-		borderError: border.brand.checkboxError,
-		backgroundChecked: background.brand.checkboxChecked,
-		text: text.brand.checkbox,
-		textSupporting: text.brand.checkboxSupporting,
-		textIndeterminate: text.brand.checkboxIndeterminate,
+		border: brandBorder.checkbox,
+		borderHover: brandBorder.checkboxHover,
+		borderChecked: brandBorder.checkboxChecked,
+		borderError: brandBorder.checkboxError,
+		backgroundChecked: brandBackground.checkboxChecked,
+		text: brandText.checkbox,
+		textSupporting: brandText.checkboxSupporting,
+		textIndeterminate: brandText.checkboxIndeterminate,
 	},
 	...inlineErrorBrand,
 }

--- a/packages/foundations/src/themes/inline-error.ts
+++ b/packages/foundations/src/themes/inline-error.ts
@@ -1,4 +1,4 @@
-import { text } from "../index"
+import { text, brandText } from "../index"
 
 export type InlineErrorTheme = {
 	text: string
@@ -12,7 +12,7 @@ export const inlineErrorDefault: { inlineError: InlineErrorTheme } = {
 
 export const inlineErrorBrand: { inlineError: InlineErrorTheme } = {
 	inlineError: {
-		text: text.brand.error,
+		text: brandText.error,
 	},
 }
 

--- a/packages/foundations/src/themes/link.ts
+++ b/packages/foundations/src/themes/link.ts
@@ -1,4 +1,4 @@
-import { text } from "../index"
+import { text, brandText, brandAltText } from "../index"
 
 export type LinkTheme = {
 	textPrimary: string
@@ -18,15 +18,15 @@ export const linkDefault: { link: LinkTheme } = {
 
 export const linkBrand: { link: LinkTheme } = {
 	link: {
-		textPrimary: text.brand.linkPrimary,
-		textPrimaryHover: text.brand.linkPrimaryHover,
+		textPrimary: brandText.linkPrimary,
+		textPrimaryHover: brandText.linkPrimaryHover,
 	},
 }
 
 export const linkBrandAlt: { link: LinkTheme } = {
 	link: {
-		textPrimary: text.brandAlt.linkPrimary,
-		textPrimaryHover: text.brandAlt.linkPrimaryHover,
+		textPrimary: brandAltText.linkPrimary,
+		textPrimaryHover: brandAltText.linkPrimaryHover,
 	},
 }
 

--- a/packages/foundations/src/themes/radio.ts
+++ b/packages/foundations/src/themes/radio.ts
@@ -1,4 +1,11 @@
-import { border, background, text } from "../index"
+import {
+	border,
+	background,
+	text,
+	brandBorder,
+	brandBackground,
+	brandText,
+} from "../index"
 import {
 	inlineErrorLight,
 	inlineErrorBrand,
@@ -34,12 +41,12 @@ export const radioBrand: {
 	inlineError: InlineErrorTheme
 } = {
 	radio: {
-		borderHover: border.brand.radioHover,
-		border: border.brand.radio,
-		backgroundChecked: background.brand.radioChecked,
-		text: text.brand.radio,
-		textSupporting: text.brand.radioSupporting,
-		borderError: border.brand.radioError,
+		borderHover: brandBorder.radioHover,
+		border: brandBorder.radio,
+		backgroundChecked: brandBackground.radioChecked,
+		text: brandText.radio,
+		textSupporting: brandText.radioSupporting,
+		borderError: brandBorder.radioError,
 	},
 	...inlineErrorBrand,
 }

--- a/packages/helpers/storybook-bg.ts
+++ b/packages/helpers/storybook-bg.ts
@@ -1,4 +1,8 @@
-import { palette } from "@guardian/src-foundations"
+import {
+	background,
+	brandBackground,
+	brandAltBackground,
+} from "@guardian/src-foundations/palette"
 import { ThemeName } from "./types"
 
 const storybookBackgrounds: {
@@ -7,17 +11,17 @@ const storybookBackgrounds: {
 		value: string
 	}
 } = {
-	default: { name: "default", value: palette.background.primary },
-	brand: { name: "brand", value: palette.background.brand.primary },
+	default: { name: "default", value: background.primary },
+	brand: { name: "brand", value: brandBackground.primary },
 	brandAlt: {
 		name: "brandAlt",
-		value: palette.background.brandAlt.primary,
+		value: brandAltBackground.primary,
 	},
 	// continue to expose legacy theme names
-	light: { name: "light", value: palette.background.primary },
+	light: { name: "light", value: background.primary },
 	brandYellow: {
 		name: "brandYellow",
-		value: palette.background.brandYellow.primary,
+		value: brandAltBackground.primary,
 	},
 }
 


### PR DESCRIPTION
## What is the purpose of this change?

Currently, importing a set of functional colours will import functional colours for all three supported themes. As the number of functional colours grows, this will increase the amount of needless JavaScript that gets shipped to the client.

Given that it is likely an application will only require one theme at a time, we should expose the functional colours on a theme-by-theme basis. 

## What does this change?

Exposes functional colours by theme, so now a consumer can do:

```ts
// default theme

import {text, background} from '@guardian/src-foundations/palette'

const body = css`
  color: ${text.primary};
  background-colour: ${background.primary}'
`
```
```ts
// brand theme

import {brandText, brandBackground} from '@guardian/src-foundations/palette'

const body = css`
  color: ${brandText.primary};
  background-colour: ${brandBackground.primary}'
`
```

