### PR TITLE
Re-expose brandYellow colour as brandAlt

### DIFF
--- a/packages/foundations/src/index.ts
+++ b/packages/foundations/src/index.ts
@@ -17,6 +17,7 @@ import {
 	brandAltLine,
 	brandAltText,
 	brand,
+	brandAlt,
 	brandYellow,
 	neutral,
 	error,
@@ -46,6 +47,7 @@ export const palette = {
 	brandAltText,
 	// global colours
 	brand,
+	brandAlt,
 	brandYellow,
 	neutral,
 	error,

--- a/packages/foundations/src/palette/background.ts
+++ b/packages/foundations/src/palette/background.ts
@@ -1,4 +1,4 @@
-import { neutral, brand, brandYellow } from "./global"
+import { neutral, brand, brandAlt } from "./global"
 
 export const background = {
 	primary: neutral[100],
@@ -22,9 +22,9 @@ export const brandBackground = {
 }
 
 export const brandAltBackground = {
-	primary: brandYellow[400],
+	primary: brandAlt[400],
 	buttonPrimary: neutral[7],
 	buttonPrimaryHover: "#454545",
-	buttonSecondary: brandYellow[300],
+	buttonSecondary: brandAlt[300],
 	buttonSecondaryHover: "#F2AE00",
 }

--- a/packages/foundations/src/palette/global.ts
+++ b/packages/foundations/src/palette/global.ts
@@ -14,7 +14,7 @@ export const brand = {
 	pastel: colors.blues[8],
 	faded: colors.blues[9],
 }
-export const brandYellow = {
+export const brandAlt = {
 	300: colors.yellows[0],
 	400: colors.yellows[1],
 
@@ -22,6 +22,8 @@ export const brandYellow = {
 	dark: colors.yellows[0],
 	main: colors.yellows[1],
 }
+// continue to expose legacy name for compatibility
+export const brandYellow = brandAlt
 export const neutral = {
 	7: colors.grays[0],
 	20: colors.grays[1],

--- a/packages/foundations/src/palette/index.ts
+++ b/packages/foundations/src/palette/index.ts
@@ -1,5 +1,6 @@
 export {
 	brand,
+	brandAlt,
 	brandYellow,
 	neutral,
 	error,


### PR DESCRIPTION
## What is the purpose of this change?

For consistency, we should move away from the name `brandYellow` towards the more neutral `brandAlt`. This would bring it into line with the name of the theme that uses the `brandYellow` background (see #190)

## What does this change?

- Re-expose the `brandYellow` global colour as `brandAlt`
- Update functional colours to point to new name
